### PR TITLE
4.1 specfile changes

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -71,7 +71,7 @@
 #define snap 0
 %if %{?snap}0
 %{expand:%%define version %(echo %{tarversion} | sed 's/-snap\..*$//')}
-%{expand:%%define release 0.adaptive.snap.%(echo %{tarversion} | sed 's/^.*-snap\.//')}.0%{?dist}}
+%{expand:%%define release 0.adaptive.snap.%(echo %{tarversion} | sed 's/^.*-snap\.//').0%{?dist}}
 %else
 %define version %{tarversion}
 %define release 1.adaptive%{?dist}


### PR DESCRIPTION
This patch provides a --with debug feature for the community specfile which allows proper disabling of compiler optimizations and binary stripping and activates maximum symbol information to be written to the binaries.

Also included are some missing configure arguments for other optional specfile features and a branding suffix update ("cri" -> "adaptive").
