### PR TITLE
Fix "make dist" and "make distcheck"

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -4,22 +4,23 @@ include_HEADERS = libcmds.h license_pbs.h pbs_constants.h pbs_cmds.h pbs_error.h
 									pbs_error_db.h pbs_ifl.h rm.h tm.h tm_.h u_hash_map_structs.h \
 									u_memmgr.h uthash.h tcp.h
 
-noinst_HEADERS = acct.h array.h assertions.h attribute.h batch_request.h \
-		 cmds.h credential.h csv.h \
-		 dis.h dis_init.h pbs_job.h libpbs.h list_link.h log.h \
-		 mcom.h md5.h mom_func.h net_connect.h pbs_assert.h \
-		 pbs_nodes.h pbs_proto.h portability.h qmgr.h \
-		 qmgr_node_public.h qmgr_node_readonly.h qmgr_que_public.h \
-		 qmgr_que_readonly.h qmgr_svr_public.h qmgr_svr_readonly.h \
-		 queue.h resmon.h resource.h sched_cmds.h server.h \
-		 server_limits.h svrfunc.h tracking.h work_task.h \
-		 port_forwarding.h pbs_cpa.h pbs_cpuset.h  \
-		 pbs_batchreqtype_db.h utils.h u_tree.h threadpool.h \
-		 resizable_array.h hash_table.h mom_hierarchy.h \
-		 dynamic_string.h mom_server.h alps_constants.h \
-		 alps_functions.h login_nodes.h track_alps_reservations.h \
-		 net_cache.h user_info.h hash_map.h exiting_jobs.h \
-		 mom_update.h
+noinst_HEADERS = acct.h array.h assertions.h attribute.h		\
+		 batch_request.h cmds.h credential.h csv.h dis.h	\
+		 dis_init.h pbs_job.h libpbs.h list_link.h log.h	\
+		 mcom.h md5.h mom_func.h mom_job_cleanup.h		\
+		 net_connect.h pbs_assert.h pbs_nodes.h pbs_proto.h	\
+		 portability.h qmgr.h qmgr_node_public.h		\
+		 qmgr_node_readonly.h qmgr_que_public.h			\
+		 qmgr_que_readonly.h qmgr_svr_public.h			\
+		 qmgr_svr_readonly.h queue.h resmon.h resource.h	\
+		 sched_cmds.h server.h server_limits.h svrfunc.h	\
+		 tracking.h work_task.h port_forwarding.h pbs_cpa.h	\
+		 pbs_cpuset.h pbs_batchreqtype_db.h utils.h u_tree.h	\
+		 threadpool.h resizable_array.h hash_table.h		\
+		 mom_hierarchy.h dynamic_string.h mom_server.h		\
+		 alps_constants.h alps_functions.h login_nodes.h	\
+		 track_alps_reservations.h net_cache.h user_info.h	\
+		 hash_map.h exiting_jobs.h mom_update.h
 
 BUILT_SOURCES = site_job_attr_def.h site_job_attr_enum.h \
 		site_qmgr_node_print.h site_qmgr_que_print.h \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -52,5 +52,5 @@ install-exec-hook:
 	   $(DESTDIR)$(sbindir)/$(program_prefix)qserverd$(program_suffix)$(EXEEXT)
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(PBS_ENVIRON)
+	rm -f $(DESTDIR)$(PBS_ENVIRON) $(DESTDIR)$(PBS_SERVER_HOME)/server_priv/nodes
 	rm -f $(DESTDIR)$(sbindir)/$(program_prefix)qserverd$(program_suffix)$(EXEEXT)

--- a/src/tools/xpbsmon/Makefile.am
+++ b/src/tools/xpbsmon/Makefile.am
@@ -49,5 +49,5 @@ install-data-hook:
 	chmod 644 tclIndex
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(XPBS_DIR)/buildindex
+	rm -f $(DESTDIR)$(XPBSMON_DIR)/buildindex
 


### PR DESCRIPTION
Fixes for "make dist" (missing header mom_job_cleanup.h) and for "make distcheck" (leftover files from "make install" which were not removed by "make uninstall")
