### PR TITLE
Reduce unnecessary node state change logging

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -300,13 +300,17 @@ void update_node_state(
 
   struct pbssubn *sp;
 
+  /* No need to do anything if newstate == oldstate */
+  if (np->nd_state == newstate)
+    return;
+
   /*
    * LOGLEVEL >= 4 logs all state changes
    *          >= 2 logs down->(busy|free) changes
    *          (busy|free)->down changes are always logged
    */
 
-  if (LOGLEVEL >= 3)
+  if (LOGLEVEL >= 4)
     {
     sprintf(log_buf, "adjusting state for node %s - state=%d, newstate=%d",
       (np->nd_name != NULL) ? np->nd_name : "NULL",


### PR DESCRIPTION
We currently get gigabytes of unnecessary node state information in our logs every day.  Have the code match the comments and only log this at loglevel >= 4.  Also, return early if there's no change to make.
