### PR TITLE
Protect against multiple definitions of typedef pbs_net_t

### DIFF
--- a/src/server/node_func.h
+++ b/src/server/node_func.h
@@ -4,7 +4,10 @@
 #include "list_link.h" /* tlist_head */
 
 /* Forward declarations. */
-typedef unsigned long pbs_net_t;
+#ifndef PBS_NET_TYPE
+typedef unsigned long pbs_net_t;        /* for holding host addresses */
+#define PBS_NET_TYPE
+#endif
 struct pbsnode;
 struct node_check_info;
 struct node_iterator;


### PR DESCRIPTION
Current head won't compile on RHEL6.  It complains about multiple definitions of pbs_net_t

In file included from ../../src/include/pbs_job.h:94,
                 from ../../src/include/batch_request.h:105,
                 from node_func.c:32:
../../src/include/server_limits.h:186: error: redefinition of typedef ‘pbs_net_t’
node_func.h:7: note: previous declaration of ‘pbs_net_t’ was here
