### PR TITLE
Fix overflow caused by wrong sizeof argument

### DIFF
--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -822,7 +822,13 @@ int handle_exiting_or_abort_substate(
   char job_id[PBS_MAXSVRJOBID+1];
   char log_buf[LOCAL_LOG_BUF_SIZE+1];
 
-  strcpy(job_id, pjob->ji_qs.ji_jobid);
+  if (pjob == NULL)
+    {
+    log_err(PBSE_BAD_PARAMETER, __func__, "NULL input job pointer");
+    return(PBSE_BAD_PARAMETER);
+    }
+  strncpy(job_id, pjob->ji_qs.ji_jobid, sizeof(job_id) - 1);
+  job_id[sizeof(job_id) - 1] = '\0';
 
   if (LOGLEVEL >= 2)
     {

--- a/src/server/test/req_jobobit/scaffolding.c
+++ b/src/server/test/req_jobobit/scaffolding.c
@@ -244,8 +244,11 @@ job *svr_find_job(char *jobid, int get_subjob)
 
   if (bad_job == 0)
     {
-    pjob = calloc(1, sizeof(pjob));
-    strcpy(pjob->ji_qs.ji_jobid, jobid);
+    pjob = calloc(1, sizeof(*pjob));
+    if (jobid != NULL)
+      {
+      strncpy(pjob->ji_qs.ji_jobid, jobid, sizeof(pjob->ji_qs.ji_jobid)-1);
+      }
     pjob->ji_wattr[JOB_ATR_reported].at_flags = ATR_VFLAG_SET;
   
     if (reported)


### PR DESCRIPTION
This bug caused an abort of req_jobobit tests. Fixed it and added a couple of useful checks.
