### PR TITLE
IMPORTANT:  4.2.0 C/C++ Linkage Issue

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,10 @@ MOSTLYCLEANFILES = *.gcda *.gcno *.gcov
 
 DISTCHECK_CONFIGURE_FLAGS=--with-server-home=$$dc_install_base/spool
 
+LIBTOOL_DEPS = @LIBTOOL_DEPS@
+libtool: $(LIBTOOL_DEPS)
+	$(SHELL) ./config.status --recheck
+
 snap:
 	$(MAKE) VERSION=$(VERSION)-snap.$${snapstamp:-`date +%Y%m%d%H%M`} dist
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,8 @@ AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([buildutils])
 
 LT_INIT
+LT_LANG([C++])
+AC_SUBST([LIBTOOL_DEPS])
 
 AC_CHECK_PROGS(MAKE,$MAKE make gmake,error)
 if test "x$MAKE" = "xerror" ;then
@@ -50,6 +52,10 @@ m4_ifdef([HAVE_CHECK],
 
 AC_PROG_CXX
 CC="$CXX"
+CCLD="$CXX"
+AC_SUBST([CCLD])
+LIBTOOLFLAGS="--tag=CXX"
+AC_SUBST([LIBTOOLFLAGS])
 AM_MAINTAINER_MODE
 
 if test "$program_prefix" = "NONE";then


### PR DESCRIPTION
This fixes a fairly major linkage issue with libtorque.so.2 in 4.2.0 which prevents OpenMPI jobs from starting.

During the TORQUE build process, C files are being compiled into object files using the C++ compiler (typically `g++`).  However, because all the component files of the libraries and executables are `*.c` and `*.h` files, they are being linked with `gcc` instead of `g++`.  This prevents the appropriate libraries (`libstdc++` and `libg++`) from being linked into, for example, `libtorque.so.2`.

Unfortunately, if one has an existing OpenMPI installation which is compiled against libtorque (for `tm` module support), attempts to replace the 4.1.x `libtorque.so.2.0.0` with the 4.2.0 `libtorque.so.2.0.0` will cause all MPI jobs to fail with an error message similar to this one:

```
mca: base: component_find: unable to open
/global/software/sl-6.x86_64/modules/intel/2011.11.339/openmpi/1.6-intel/lib/openmpi/mca_plm_tm:
/usr/lib64/libtorque.so.2: undefined symbol: __gxx_personality_v0
```

This is caused by the aforementioned libraries being missing from the dependency tree for the new `libtorque.so.2.0.0` from torque 4.2.0.

This pull request references a fix for this issue.  It forces the torque build process to use `g++` (or, more specifically, `$(CXX)`) for linking instead of `gcc` (`$(CC)`).  Our testing shows that this allows `libtorque.so.2.0.0` to be a drop-in replacement for the previous version (as it should be, given the lack of change to the SOVERSION).
