### PR TITLE
Make sure to only print cray_enabled properties to the node file once

### DIFF
--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -1334,7 +1334,13 @@ int update_nodes_file(
 
     /* write out properties */
     for (j = 0;j < np->nd_nprops - 1;++j)
-      fprintf(nin, " %s", np->nd_prop->as_string[j]);
+      {
+      /* Don't write out the cray_enabled features here */
+      if (strcmp(np->nd_prop->as_string[j], "cray_compute") &&
+          strcmp(np->nd_prop->as_string[j], alps_reporter_feature) &&
+          strcmp(np->nd_prop->as_string[j], alps_starter_feature))
+        fprintf(nin, " %s", np->nd_prop->as_string[j]);
+      }
 
     if (np->nd_is_alps_reporter == TRUE)
       fprintf(nin, " %s", alps_reporter_feature);


### PR DESCRIPTION
If the pbs_server has to rewrite the nodes file, it might write the
cray_enabled features multiple times.  It may also incorrectly put
the cray_compute property on the alps_reporter.
