### PR TITLE
TRQ-1666. With resources_available.nodect set TORQUE 4.x

### DIFF
--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -3078,17 +3078,20 @@ int node_spec(
 #ifndef CRAY_MOAB_PASSTHRU
     if (eligible_nodes < num)
       {
-      /* sufficient eligible nodes do not exist */
-      /* FAILURE */
-      sprintf(log_buf,
-        "job requesting nodes that will never be available - spec = %s",
-        spec_param);
+      if ((SvrNodeCt == 0) || (SvrNodeCt < num))
+        {
+        /* sufficient eligible nodes do not exist */
+        /* FAILURE */
+        sprintf(log_buf,
+          "job requesting nodes that will never be available - spec = %s",
+          spec_param);
 
-      log_err(-1, __func__, log_buf);
-      if (naji != NULL)
-        release_node_allocation(naji);
+        log_err(-1, __func__, log_buf);
+        if (naji != NULL)
+          release_node_allocation(naji);
 
-      return(-1);
+        return(-1);
+        }
       }
 #endif
     }


### PR DESCRIPTION
was rejecting node requests that asked for nodes with
features and the number requested exceeded the actual node with
those features. If resources_available.nodect is not set it
should fail. If resources_available.nodect is set is should
succeed.
