### PR TITLE
Moved the file for trqauthd unix domain socket file to /tmp.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1693,6 +1693,14 @@ fi
 AC_MSG_RESULT([$ENABLE_UNIX_SOCKETS])
 
 
+AC_ARG_WITH(trqauthd_sock_dir, [
+  --with-trqauthd-sock-dir=DIR  set trqauthd directory for unix domain socket file
+                          defaults to /tmp],
+    [TRQAUTHD_SOCK_DIR="${withval}" ; RPM_AC_OPTS="$RPM_AC_OPTS --define \"torque_auth_sock_dir ${withval}\"" ],
+    [TRQAUTHD_SOCK_DIR="/tmp"])
+AC_DEFINE_UNQUOTED(TRQAUTHD_SOCK_DIR, "${TRQAUTHD_SOCK_DIR}", "trqauthd unix domain file")
+
+
 AC_ARG_WITH(server_home, [
   --with-server-home=DIR  set the server home/spool directory for PBS use
                           defaults to /var/spool/torque],

--- a/src/daemon_client/trq_auth_daemon.c
+++ b/src/daemon_client/trq_auth_daemon.c
@@ -174,7 +174,7 @@ int daemonize_trqauthd(const char *server_ip, int server_port, void *(*process_m
     pthread_mutex_unlock(log_mutex);
 
     /* start the listener */
-    snprintf(unix_socket_name, sizeof(unix_socket_name), "%s/%s", path_home, TRQAUTHD_SOCK_NAME);
+    snprintf(unix_socket_name, sizeof(unix_socket_name), "%s/%s", TRQAUTHD_SOCK_DIR, TRQAUTHD_SOCK_NAME);
     rc = start_domainsocket_listener(unix_socket_name, process_meth);
     if(rc != PBSE_NONE)
       {

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -566,7 +566,7 @@ int validate_socket(
     }
   else
     {
-    snprintf(unix_sockname, sizeof(unix_sockname), "%s/%s", PBS_SERVER_HOME, TRQAUTHD_SOCK_NAME);
+    snprintf(unix_sockname, sizeof(unix_sockname), "%s/%s", TRQAUTHD_SOCK_DIR, TRQAUTHD_SOCK_NAME);
     /* format is:
      * trq_system|trq_port|Validation_type|user|pid|psock|
      */


### PR DESCRIPTION
Also added configure option --with-trqauthd-sock-dir so users
can choose where to locate the file.
