### PR TITLE
rewords configure.ac to make less ambiguous 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -713,7 +713,7 @@ TAC_SYS_LARGEFILE
 dnl We need pthreads
 AC_CHECK_LIB(pthread, pthread_create, 
     PTHREAD_LIBS="$PTHREAD_LIBS -lpthread -lrt",
-    [AC_MSG_ERROR([TORQUE needs pthreads in order to build]) ])
+    [AC_MSG_ERROR([TORQUE needs pthreads in order to build, install gcc-g++]) ])
 LIBS="$LIBS $PTHREAD_LIBS"
 
 


### PR DESCRIPTION
When gcc-g++ is not installed, the end user gets a confusing error. "TORQUE needs pthreads..."
Rewords the error message to tell the user _how_ to install pthreads.

http://spuder.wordpress.com/2013/04/10/configure-error-torque-needs-pthreads-in-order-to-build/
