### PR TITLE
Cray Orphan Handling

### DIFF
--- a/src/include/track_alps_reservations.h
+++ b/src/include/track_alps_reservations.h
@@ -109,7 +109,7 @@ void initialize_alps_reservations();
 
 int track_alps_reservation(job *pjob);
 int remove_alps_reservation(char *rsv_id);
-int is_orphaned(char *rsv_id);
+int is_orphaned(char *rsv_id, char *job_id);
 int already_recorded(char *rsv_id);
 int insert_alps_reservation(alps_reservation *ar);
 

--- a/src/server/process_alps_status.c
+++ b/src/server/process_alps_status.c
@@ -202,13 +202,14 @@ void *check_if_orphaned(
 
   {
   char                 *rsv_id = (char *)vp;
+  char                  job_id[PBS_MAXSVRJOBID];
   struct batch_request *preq;
   int                   handle = -1;
   int                   retries = 0;
   struct pbsnode       *pnode;
   char                  log_buf[LOCAL_LOG_BUF_SIZE];
 
-  if (is_orphaned(rsv_id) == TRUE)
+  if (is_orphaned(rsv_id, job_id) == TRUE)
     {
     if((preq = alloc_br(PBS_BATCH_DeleteReservation)) == NULL)
       return NULL;
@@ -227,8 +228,9 @@ void *check_if_orphaned(
       momaddr = ntohl(hostaddr.s_addr);
 
       snprintf(log_buf, sizeof(log_buf),
-        "Found orphan ALPS reservation ID %s; asking %s to remove it",
+        "Found orphan ALPS reservation ID %s for job %s; asking %s to remove it",
         rsv_id,
+        job_id,
         pnode->nd_name);
       log_record(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, __func__, log_buf);
 

--- a/src/server/test/process_alps_status/scaffolding.c
+++ b/src/server/test/process_alps_status/scaffolding.c
@@ -2138,7 +2138,8 @@ void free_null(struct pbs_attribute *attr) {}
 
 int is_orphaned(
 
-  char *rsv_id)
+  char *rsv_id,
+  char *job_id)
 
   {
   return(1);

--- a/src/server/test/track_alps_reservations/test_track_alps_reservations.c
+++ b/src/server/test/track_alps_reservations/test_track_alps_reservations.c
@@ -64,6 +64,7 @@ END_TEST
 START_TEST(insert_create_inspect_test)
   {
   job               pjob;
+  char              job_id[PBS_MAXSVRJOBID];
 
   strcpy(pjob.ji_qs.ji_jobid, jobids[0]);
   pjob.ji_wattr[JOB_ATR_reservation_id].at_val.at_str = rsvids[0];
@@ -99,10 +100,10 @@ START_TEST(insert_create_inspect_test)
   fail_unless(already_recorded((char *)"tom") == 0,     "missing rsv_id somehow found");
   fail_unless(already_recorded((char *)"tommy") == 0,   "missing rsv_id somehow found");
 
-  fail_unless(is_orphaned(rsvids[0]) == 1, "no job but not orphaned?");
-  fail_unless(is_orphaned(rsvids[1]) == 0, "job 1 returned but orphaned?");
-  fail_unless(is_orphaned(rsvids[2]) == 0, "job 2 returned but orphaned?");
-  fail_unless(is_orphaned(rsvids[3]) == 1, "completed job but not orphaned?");
+  fail_unless(is_orphaned(rsvids[0], job_id) == 1, "no job but not orphaned?");
+  fail_unless(is_orphaned(rsvids[1], job_id) == 0, "job 1 returned but orphaned?");
+  fail_unless(is_orphaned(rsvids[2], job_id) == 0, "job 2 returned but orphaned?");
+  fail_unless(is_orphaned(rsvids[3], job_id) == 1, "completed job but not orphaned?");
 
   fail_unless(remove_alps_reservation((char *)"00") == THING_NOT_FOUND, "found something that doesn't exist");
   fail_unless(remove_alps_reservation(rsvids[0]) == 0, "couldn't remove reservation 1");

--- a/src/server/track_alps_reservations.c
+++ b/src/server/track_alps_reservations.c
@@ -233,7 +233,8 @@ int already_recorded(
 
 int is_orphaned(
 
-  char *rsv_id)
+  char *rsv_id,
+  char *job_id)
 
   {
   int               index;
@@ -249,6 +250,9 @@ int is_orphaned(
 
   if (ar != NULL)
     {
+    if (job_id != NULL)
+      strncpy(job_id, ar->job_id, PBS_MAXSVRJOBID);
+
     if ((pjob = svr_find_job(ar->job_id, TRUE)) != NULL)
       {
       if (pjob->ji_qs.ji_state == JOB_STATE_COMPLETE)
@@ -260,7 +264,11 @@ int is_orphaned(
       orphaned = TRUE;
     }
   else
+    {
+    if (job_id != NULL)
+      snprintf(job_id, PBS_MAXSVRJOBID, "unknown");
     orphaned = TRUE;
+    }
 
   return(orphaned);
   } /* END is_orphaned() */


### PR DESCRIPTION
Make sure to remove orphan ALPS reservations from the reservation hash table.  Also log the Job ID of orphan reservations.
