### PR TITLE
Fix retry logic when PBSAPITIMEOUT is set

### DIFF
--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -1019,14 +1019,14 @@ int pbs_original_connect(
         rc = trq_set_preferred_network_interface(if_name, &preferred_addr);
         if (rc != PBSE_NONE)
           {
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             fprintf(stderr, "could not set preferred network interface (%s): %d\n",
                   if_name, rc);
 
           if (if_name)
             free(if_name);
 
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             {
             rc = rc * -1;
             goto cleanup_conn;
@@ -1045,14 +1045,14 @@ int pbs_original_connect(
         rc = bind(connection[out].ch_socket, &preferred_addr, sizeof(struct sockaddr));
         if (rc < 0)
           {
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             fprintf(stderr, "ERROR: could not bind preferred network interface (%s): errno: %d",
                   if_name, errno);
 
           if (if_name)
             free(if_name);
 
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             {
             rc = PBSE_SYSTEM * -1;
             goto cleanup_conn;
@@ -1080,14 +1080,14 @@ int pbs_original_connect(
         {
         if (getenv("PBSDEBUG"))
           {
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             fprintf(stderr, "ERROR:  cannot get servername (%s) errno=%d (%s)\n",
                   (server != NULL) ? server : "NULL",
                   errno,
                   strerror(errno));
           }
 
-        if (retries >= MAX_RETRIES)
+        if (!retry || retries >= MAX_RETRIES)
           {
           rc = PBSE_BADHOST * -1;
           goto cleanup_conn;
@@ -1111,7 +1111,7 @@ int pbs_original_connect(
       /* Set the socket to non-blocking mode so we can timeout */
       if ((sockflags = fcntl(connection[out].ch_socket, F_GETFL, NULL)) < 0)
         {
-        if (retries >= MAX_RETRIES)
+        if (!retry || retries >= MAX_RETRIES)
           {
           if (getenv("PBSDEBUG"))
             fprintf(stderr, "ERROR:  getting socket flags failed\n");
@@ -1134,7 +1134,7 @@ int pbs_original_connect(
 
       if (fcntl(connection[out].ch_socket, F_SETFL, sockflags) < 0)
         {
-        if (retries >= MAX_RETRIES)
+        if (!retry || retries >= MAX_RETRIES)
           {
           if (getenv("PBSDEBUG"))
             fprintf(stderr, "ERROR:  setting socket flags failed\n");
@@ -1178,7 +1178,7 @@ int pbs_original_connect(
               if (getenv("PBSDEBUG"))
                 fprintf(stderr, "ERROR: socket has error status %d\n", rc);
          
-              if (retries >= MAX_RETRIES)
+              if (!retry || retries >= MAX_RETRIES)
                 {
                 rc = PBSE_SOCKET_FAULT * -1;
                 goto cleanup_conn;
@@ -1203,7 +1203,7 @@ int pbs_original_connect(
                 (int)pbs_tcp_timeout);
               }
               
-            if (retries >= MAX_RETRIES)
+            if (!retry || retries >= MAX_RETRIES)
               {
               rc = PBSE_TIMEOUT * -1;
               goto cleanup_conn;
@@ -1226,7 +1226,7 @@ int pbs_original_connect(
                 rc, errno, strerror(errno));
               }
 
-            if (retries >= MAX_RETRIES)
+            if (!retry || retries >= MAX_RETRIES)
               {
               rc = PBSE_SELECT * -1;
               goto cleanup_conn;
@@ -1247,7 +1247,7 @@ int pbs_original_connect(
           if (getenv("PBSDEBUG"))
             fprintf(stderr, "ERROR: connect failed\n");
 
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             {
             rc = PBSE_SOCKET_FAULT * -1;
             goto cleanup_conn;
@@ -1272,7 +1272,7 @@ int pbs_original_connect(
         if (getenv("PBSDEBUG"))
           fprintf(stderr, "ERROR: setting socket flags failed\n");
 
-        if (retries >= MAX_RETRIES)
+        if (!retry || retries >= MAX_RETRIES)
           {
           rc = PBSE_SOCKET_FAULT * -1;
           goto cleanup_conn;
@@ -1317,7 +1317,7 @@ int pbs_original_connect(
           }
         else
           {
-          if (retries >= MAX_RETRIES)
+          if (!retry || retries >= MAX_RETRIES)
             {
             local_errno = PBSE_PERM;
             


### PR DESCRIPTION
Previously, when PBSAPITIMEOUT was set, failures were not correctly
reported.  The functions would move on to DIS and then get end-of-
file messages:
$ PBSAPITIMEOUT=3 /opt/torque/default/bin/qstat @down-server
qstat: End of File

Now, it properly handles bad return codes and gives a useful
message:
$ PBSAPITIMEOUT=3 /opt/torque/default/bin/qstat @down-server
Error communicating with down-server(192.168.1.10)
Communication failure.
qstat: cannot connect to server down-server (errno=15085) Time out

This probably needs to be merged into master, 4.2-dev, and 4.1-dev
