### PR TITLE
Have qstat request specific attributes

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2270,10 +2270,6 @@ int main(
 
         alt_opt |= ALT_DISPLAY_a;
 
-        set_attr(&attrib, ATTR_session, NULL);
-        set_attr(&attrib, ATTR_used, NULL);
-        set_attr(&attrib, ATTR_l, NULL);
-
         break;
 
       case 'e':
@@ -2303,6 +2299,9 @@ int main(
 
         alt_opt |= ALT_DISPLAY_n;
 
+        if (attrib != NULL)
+          set_attr(&attrib, ATTR_exechost, NULL);
+
         break;
 
       case 'q':
@@ -2324,6 +2323,9 @@ int main(
       case 's':
 
         alt_opt |= ALT_DISPLAY_s;
+
+        if (attrib != NULL)
+          set_attr(&attrib, ATTR_comment, NULL);
 
         break;
 
@@ -2615,6 +2617,14 @@ int main(
   if (def_server == NULL)
     def_server = "";
 
+  /* Alternate display requires a few extra attributes */
+  if (alt_opt && (attrib != NULL))
+    {
+    set_attr(&attrib, ATTR_session, NULL);
+    set_attr(&attrib, ATTR_used, NULL);
+    set_attr(&attrib, ATTR_l, NULL);
+    }
+
   if (alt_opt & ALT_DISPLAY_u)
     {
     if (f_opt == 0)
@@ -2809,11 +2819,15 @@ job_no_args:
           {
           if (t_opt)
             {
-            p_status = pbs_selstat_err(connect, p_atropl, exec_only ? (char *)EXECQUEONLY : NULL, &any_failed);
+            p_status = pbs_selstatattr_err(connect, p_atropl, attrib, exec_only ? (char *)EXECQUEONLY : NULL, &any_failed);
+            if (any_failed == PBSE_UNKREQ)
+              p_status = pbs_selstat_err(connect, p_atropl, exec_only ? (char *)EXECQUEONLY : NULL, &any_failed);
             }
           else
             {
-            p_status = pbs_selstat_err(connect, p_atropl, exec_only ? (char *)EXECQUEONLY : (char *)summarize_arrays_extend_opt, &any_failed);
+            p_status = pbs_selstatattr_err(connect, p_atropl, attrib, exec_only ? (char *)EXECQUEONLY : (char *)summarize_arrays_extend_opt, &any_failed);
+            if (any_failed == PBSE_UNKREQ)
+              p_status = pbs_selstat_err(connect, p_atropl, exec_only ? (char *)EXECQUEONLY : (char *)summarize_arrays_extend_opt, &any_failed);
             }
           }
 

--- a/src/include/pbs_batchreqtype_db.h
+++ b/src/include/pbs_batchreqtype_db.h
@@ -80,5 +80,6 @@ PbsBatchReqType(PBS_BATCH_AsySignalJob,         "AsyncSignalJob")     /* = 60 */
 PbsBatchReqType(PBS_BATCH_AltAuthenUser,        "AlternateUserAuthentication") 
 PbsBatchReqType(PBS_BATCH_GpuCtrl,              "GPUControl") 
 PbsBatchReqType(PBS_BATCH_DeleteReservation,    "DeleteAlpsReservation")
+PbsBatchReqType(PBS_BATCH_SelStatAttr,          "SelStatAttr")
 #endif
 #endif /* _PBS_BATCHREQTYPE_DB_H */

--- a/src/lib/Libifl/lib_ifl.h
+++ b/src/lib/Libifl/lib_ifl.h
@@ -311,6 +311,7 @@ int pbs_runjob_err(int c, char *jobid, char *location, char *extend, int *);
 /* pbsD_selectj.c */
 char ** pbs_selectjob_err(int c, struct attropl *attrib, char *extend, int *);
 struct batch_status * pbs_selstat_err(int c, struct attropl *attrib, char *extend, int *);
+struct batch_status * pbs_selstatattr_err(int c, struct attropl *attropl, struct attrl *attrib, char *extend, int *);
 /* static int PBSD_select_put(int c, int type, struct attropl *attrib, char *extend); */
 /* static char **PBSD_select_get(int c); */
 

--- a/src/server/dis_read.c
+++ b/src/server/dis_read.c
@@ -318,6 +318,16 @@ int dis_request_read(
 
       break;
 
+    case PBS_BATCH_SelStatAttr:
+
+      CLEAR_HEAD(request->rq_ind.rq_select);
+      CLEAR_HEAD(request->rq_ind.rq_status.rq_attr);
+
+      rc = decode_DIS_svrattrl(chan, &request->rq_ind.rq_select);
+      rc = decode_DIS_svrattrl(chan, &request->rq_ind.rq_status.rq_attr);
+
+      break;
+
     case PBS_BATCH_StatusNode:
 
     case PBS_BATCH_StatusQue:

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -861,6 +861,8 @@ int dispatch_request(
 
     case PBS_BATCH_SelStat:
 
+    case PBS_BATCH_SelStatAttr:
+
       /* handle special 'truncated' keyword */
 
       if (!strncasecmp(request->rq_ind.rq_status.rq_id, "truncated", strlen("truncated")))
@@ -1200,6 +1202,13 @@ void free_br(
     case PBS_BATCH_SelStat:
 
       free_attrlist(&preq->rq_ind.rq_select);
+
+      break;
+
+    case PBS_BATCH_SelStatAttr:
+
+      free_attrlist(&preq->rq_ind.rq_select);
+      free_attrlist(&preq->rq_ind.rq_status.rq_attr);
 
       break;
 

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -509,12 +509,11 @@ static void sel_step3(
   job       *next;
 
   struct batch_request *preq;
-
   struct batch_reply   *preply;
-
   struct brp_select    *pselect;
-
   struct brp_select   **pselx;
+  struct svrattrl      *pal;
+
   int        rc = 0;
   int        exec_only = 0;
   pbs_queue           *pque = NULL;
@@ -546,6 +545,7 @@ static void sel_step3(
     }
 
   pselx = &preply->brp_un.brp_select;
+  pal = (svrattrl *)GET_NEXT(preq->rq_ind.rq_status.rq_attr);
 
   if (preq->rq_extend != NULL)
     if (!strncmp(preq->rq_extend, EXECQUEONLY, strlen(EXECQUEONLY)))
@@ -626,7 +626,7 @@ static void sel_step3(
           {
           /* Select-Status */
 
-          rc = status_job(pjob, preq, NULL, &preply->brp_un.brp_status, &bad);
+          rc = status_job(pjob, preq, pal, &preply->brp_un.brp_status, &bad);
 
           if (rc && (rc != PBSE_PERM))
             {


### PR DESCRIPTION
This request has three commits:
- Fix 'qstat -u <username>' which was recently broken when support was added for 'qstat -f -u <username>'
- Request specific attributes from qstat to avoid unnecessary network traffic (changes only in qstat.c)
- Add a new batch request type SelStatAttr to allow status requests specify an attropl and an attrl to both filter and specify which attributes need to be returned.  qstat will fall back to SelStat if SelStatAttr is not supported on the server

In aggregate, this will significantly reduce the amount of data over the wire, especially on large systems (since the exec_host list can be a couple MB).

I'm very comfortable with the first commit and fairly comfortable with the second.  The third is a little outside of my comfort zone, so please review it carefully and let me know if there are any suggested changes.
