### PR TITLE
Fix pesky 'Non-digit found where a digit was expected' errors

### DIFF
--- a/src/lib/Libifl/tcp_dis.c
+++ b/src/lib/Libifl/tcp_dis.c
@@ -238,6 +238,7 @@ int tcp_read(
     {
     memcpy(tp->tdis_eod, new_data, *read_len);
     tp->tdis_eod += *read_len;
+    *tp->tdis_eod = '\0';
     *avail_len = tp->tdis_eod - tp->tdis_leadp;
     max_read_len = tp->tdis_eod - tp->tdis_thebuf;
 


### PR DESCRIPTION
Copying new data into the DIS buffer didn't NULL-terminate the
string (because it's not actually the end of the string, so why
would it?).  The problem comes if the new data exceeds the buffer
size: it uses snprintf with "%s%s" to copy the old and new data
into the new buffer.  Since the old data isn't NULL-terminated,
you will get bogus data in the middle of your new buffer.

Note: this fix is to just set the EOD pointer to NULL.  Alternatively, one could swap the memcpy with a snprintf using length *read_len +1.
