### PR TITLE
Handle condition of invalid submit filter more gracefully.

### DIFF
--- a/src/cmds/qsub_functions.c
+++ b/src/cmds/qsub_functions.c
@@ -707,6 +707,8 @@ int validate_submit_filter(
       {
       rc = 1;
       }
+    else
+      rc = -1;
     }
   else if (stat(SUBMIT_FILTER_PATH, &sfilter) != -1)
     {
@@ -4129,7 +4131,15 @@ void main_func(
   process_config_file(&ji);
 
   /* check/set submit filter_path */
-  validate_submit_filter(&ji.mm, &ji.job_attr);
+  if (validate_submit_filter(&ji.mm, &ji.job_attr) == -1)
+  {
+     hash_find(ji.job_attr, ATTR_pbs_o_submit_filter, &tmp_job_info);
+     fprintf(stderr,
+             "qsub: invalid submit filter: \"%s\"\n",
+             tmp_job_info->value);
+
+     exit(1);
+  }
 
   /* NOTE:  load config before processing opts since config may modify how opts are handled */
 


### PR DESCRIPTION
Trying this again!

While tracking down a very obscure issue with qsub (there's a list of about 15 requirements to reproduce) I found that the PBS_O_SUBMIT_FILTER was being checked for validity but nothing was actually being done with the results of said check. I may file an issue about the obscure issue if I can get some more data points, but essentially the PBS_O_SUBMIT_FILTER gets lost and ends up as a null string. This produces some mystical errors when trying to submit a job.

This change probably isn't super useful, but this would have given us a head start on where to look for the cause of the mystical errors. I can see the argument that invalid filters may be fairly obvious ("sh: /invalid/submit/filter: not found") on run time but that doesn't seem very graceful. Why bother stat()'ing the filter in validate_submit_filter() if the results aren't being acted on?

This is my first time jumping into torque code so this may not be the best way to code this :)
