### PR TITLE
Fixes: torque.setup parameter list

### DIFF
--- a/torque.setup
+++ b/torque.setup
@@ -4,7 +4,7 @@
 # USAGE:  torque.setup <USERNAME> [<HOSTNAME>]
 
 if [ "$1" = "" ] ; then
-  echo "USAGE:  torque.setup <USERNAME>"
+  echo "USAGE:  torque.setup <USERNAME> [<HOSTNAME.DOMAIN>]"
   exit 1
   fi
 


### PR DESCRIPTION
Torque.setup usage message, now makes clear that 2 parameters are allowed

Resolves Issue
 #145
