### PR TITLE
Libnet:  remove unused header

### DIFF
--- a/src/lib/Libnet/net_client.c
+++ b/src/lib/Libnet/net_client.c
@@ -80,7 +80,6 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <rpc/rpc.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <errno.h>


### PR DESCRIPTION
Do not include <rpc/rpc.h> as it is unused.  While this is normally
harmless, glibc is dropping support for rpc as of 2.14 [1] and ipv6 is
only supported in ti-rpc.

This fixes building on distros that have not manually patched rpc
support back into glibc.
1. http://sourceware.org/bugzilla/show_bug.cgi?id=12949
