### PR TITLE
Fix get_fullhostname when src is already a FQDN and src/dst are the same

### DIFF
--- a/src/lib/Libnet/get_hostname.c
+++ b/src/lib/Libnet/get_hostname.c
@@ -134,7 +134,8 @@ int get_fullhostname(
   dot = strchr(shortname, '.');
   if (dot != NULL)
     {
-    snprintf(namebuf, bufsize, "%s", shortname);
+    if (shortname != namebuf)
+      snprintf(namebuf, bufsize, "%s", shortname);
     return(PBSE_NONE);
     }
 

--- a/src/lib/Libnet/test/get_hostname/scaffolding.c
+++ b/src/lib/Libnet/test/get_hostname/scaffolding.c
@@ -5,7 +5,7 @@
 
 int insert_addr_name_info(
     
-  const char               *hostname,
+  char               *hostname,
   char               *full_hostname,
   struct sockaddr_in *sai)
 
@@ -15,8 +15,8 @@ int insert_addr_name_info(
 
 char *get_cached_fullhostname(
 
-  const char               *hostname,
-  const struct sockaddr_in *sai)
+  char               *hostname,
+  struct sockaddr_in *sai)
 
   {
   return(NULL);

--- a/src/lib/Libnet/test/get_hostname/test_get_hostname.c
+++ b/src/lib/Libnet/test/get_hostname/test_get_hostname.c
@@ -28,6 +28,9 @@ START_TEST(get_fullhostname_canonical_name_in)
   fail_unless(rc == PBSE_NONE, log_msg);
   fail_unless((strcmp(canonical_name, server_name) == 0), "names are not the same");
 
+  rc = get_fullhostname(canonical_name, canonical_name, bufsize, EMsg);
+  fail_unless((strcmp(canonical_name, "kmn.ac") == 0), "name did not match what was given");
+
 
   }
 END_TEST


### PR DESCRIPTION
Several places in the code give get_fullhostname the same source and
destination buffers, meaning "update my buffer to be the full hostname".
If the source is already a FQDN, don't attempt to snprintf over itself.

This was broken by commit 770dfad7b2336a2ee508d05693737d08ddd9357f
