### PR TITLE
Make array jobs compatible with 'display_job_server_suffix = False'

### DIFF
--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -91,10 +91,20 @@ int is_array(
 
   char      *bracket_ptr;
   char      *end_bracket_ptr;
+  char      *tmpjobid;
   char       jobid[PBS_MAXSVRJOBID];
   char       temp_jobid[PBS_MAXSVRJOBID];
 
-  snprintf(jobid, sizeof(jobid), "%s", id);
+  tmpjobid = get_correct_jobname(id);
+  if (tmpjobid == NULL)
+    {
+    /* Maybe we should just return ENOMEM? */
+    snprintf(jobid, sizeof(jobid), "%s", id);
+  else
+    {
+    snprintf(jobid, sizeof(jobid), "%s", tmpjobid);
+    free(tmpjobid);
+    }
 
   /* Check to see if we have an array dependency */
   /* If there is an array dependency count then we will */
@@ -157,15 +167,21 @@ job_array *get_array(
 
   {
   job_array *pa;
-  
+  char      *tmpjobid;
+
+  tmpjobid = get_correct_jobname(id);
+
   pthread_mutex_lock(allarrays.allarrays_mutex);
 
-  pa = (job_array *)get_from_hash_map(allarrays.hm, id);
+  pa = (job_array *)get_from_hash_map(allarrays.hm, tmpjobid);
 
   if (pa != NULL)
     lock_ai_mutex(pa, __func__, NULL, LOGLEVEL);
 
   pthread_mutex_unlock(allarrays.allarrays_mutex);
+
+  if (tmpjobid != NULL)
+    free(tmpjobid);
 
   return(pa);
   } /* END get_array() */


### PR DESCRIPTION
Seems like there might be a better way to handle this; instead of having every function call get_correct_jobname() maybe it should happen somewhere early on...
