### PR TITLE
Fix for 'qstat -a' showing walltime for elapsed time for held jobs

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -818,7 +818,7 @@ static void altdsp_statjob(
       pat = pat->next;
       }
 
-    if ((*jstate != 'Q') && (*jstate != 'C'))
+    if ((*jstate != 'Q') && (*jstate != 'C') && (*jstate != 'H'))
       {
       elap_time = req_walltime - rem_walltime;
       time_to_string(elap_time_string, elap_time);


### PR DESCRIPTION
I don't think Held jobs should ever have 'elapsed time', so this patch has it just show dashes.  If there is a legitimate use case where a held job should show an elapsed time, then rem_walltime needs to be properly initialized.
