### PR TITLE
Fix unit tests - July 15

### DIFF
--- a/src/lib/Libifl/test/trq_auth/test_trq_auth.c
+++ b/src/lib/Libifl/test/trq_auth/test_trq_auth.c
@@ -59,7 +59,7 @@ END_TEST
 
 START_TEST(test_trq_simple_connect)
   {
-  const char *server_name = "kmn";
+  const char *server_name = "localhost";
   int         batch_port = 15001;
   int         handle = -1;
   int         rc;
@@ -120,7 +120,7 @@ START_TEST(test_validate_server)
   write_success = true;
   socket_read_success = true;
 
-  strcpy(active_server_name, "kmn");
+  strcpy(active_server_name, "localhost");
   rc = validate_server(active_server_name, port, ssh_key, &sign_key);
   fail_unless(rc == PBSE_NONE, "validate_server success case failed", rc);
 
@@ -132,7 +132,7 @@ START_TEST(test_set_active_pbs_server)
   char new_server_name[PBS_MAXHOSTNAME + 1];
   int rc;
 
-  strcpy(new_server_name, "kmn");
+  strcpy(new_server_name, "localhost");
   rc = set_active_pbs_server(new_server_name);
   fail_unless(rc == PBSE_NONE, "set_active_pbs_server failed", rc);
 

--- a/src/lib/Libnet/test/net_cache/Makefile.am
+++ b/src/lib/Libnet/test/net_cache/Makefile.am
@@ -9,7 +9,7 @@ AM_LDFLAGS = @CHECK_LIBS@ ${lib_LTLIBRARIES}
 check_PROGRAMS = test_net_cache
 
 libnet_cache_la_SOURCES = scaffolding.c ${PROG_ROOT}/net_cache.c ${PROG_ROOT}/../Libutils/u_hash_table.c
-libnet_cache_la_LDFLAGS = @CHECK_LIBS@ -shared -lgcov -lQtCore
+libnet_cache_la_LDFLAGS = @CHECK_LIBS@ -shared -lgcov
 
 test_net_cache_SOURCES = test_net_cache.c
 

--- a/src/lib/Libnet/test/net_cache/scaffolding.c
+++ b/src/lib/Libnet/test/net_cache/scaffolding.c
@@ -5,7 +5,6 @@
 #include <sys/types.h>
 #include <netdb.h>
 #include <pthread.h>
-#include<QtCore/qglobal.h>
 
 
 const char *words[] =
@@ -247,10 +246,10 @@ const char *words[] =
         "X-ray"
 };
 
-const char *getRandomWord()
+const char *getRandomWord(unsigned int *seedp)
 {
     int len = sizeof(words)/sizeof(const char *);
-    int index = qrand()%len;
+    int index = rand_r(seedp)%len;
 
     return words[index];
 }

--- a/src/server/test/pbsd_main/scaffolding.c
+++ b/src/server/test/pbsd_main/scaffolding.c
@@ -523,9 +523,3 @@ void log_err(int errnum, const char *routine, const char *text) {}
 void log_record(int eventtype, int objclass, const char *objname, const char *text) {}
 void log_event(int eventtype, int objclass, const char *objname, const char *text) {}
 void log_ext(int eventtype, const char *func_name, const char *msg, int level) {}
-
-int initialize_ruserok_mutex()
-  {
-  return(0);
-  }
-


### PR DESCRIPTION
- Most site don't have a server named 'kmn' - use localhost
- Avoid pulling in QT commands just to get a threadsafe rand()
- A scaffolding file defined the same function twice
