### PR TITLE
Set trqauthd to connect to all valid addresses/protocols

### DIFF
--- a/src/lib/Libifl/trq_auth.c
+++ b/src/lib/Libifl/trq_auth.c
@@ -485,7 +485,7 @@ int build_active_server_response(
     len = strlen(active_pbs_server);
     }
 
-  sprintf(temp_buf, "%d", len);
+  sprintf(temp_buf, "%d|", len);
 
   resp_msg = (char *)calloc(1, len + strlen(temp_buf) + 2); /* 2 because we need one for the '|' delimeter and one for a null termination */
   if (resp_msg == NULL)


### PR DESCRIPTION
Modifies trq_simple_connect() so it tries all entries returned by
getaddrinfo() instead of giving up if the connection fails. For example,
given an /etc/hosts of:
127.0.0.1 localhost
::1       localhost

trqauthd will now try both the IPv6 and IPv4 addresses.

Previously, if getaddrinfo() returned the IPv6 address first and
pbs_server wasn't listening on this address, then trqauthd would
not try to connect to the IPv4 address.
