### PR TITLE
Fix logic for parsing port number out of string (Issue #169)

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2314,28 +2314,35 @@ static int get_port(
   int   local_errno = 0;
 
   if (*arg == ':')
-    ++arg;
-
-  if (isdigit(*arg))
     {
+    ++arg;
     /* port only specified */
-
     *port = (unsigned int)atoi(arg);
     }
   else
     {
-    name = parse_servername(arg, port);
+    char *a;
 
-    if (name == NULL)
+    for (a = arg; *a && isdigit(*a); a++);
+    if ((! *a) && ((*port = (unsigned int)atoi(arg)) > 0) && (*port <= 65535))
       {
-      /* FAILURE */
-
-      return(-1);
+      /* port only specified */
       }
+    else
+      {
+      name = parse_servername(arg, port);
 
-    *addr = get_hostaddr(&local_errno, name);
+      if (name == NULL)
+        {
+        /* FAILURE */
 
-    free(name);
+        return(-1);
+        }
+
+      *addr = get_hostaddr(&local_errno, name);
+
+      free(name);
+      }
     }
 
   if ((*port <= 0) || (*addr == 0))


### PR DESCRIPTION
New logic is: 
1. If the string starts with a colon, it must be port number only.
2. If the string consists ENTIRELY of digits, and it converts to a
   valid TCP/UDP port number, assume it's only a port number.
3. Otherwise, parse it as a hostname with a possible ":port" suffix.
