### PR TITLE
Update disrsi_.c

### DIFF
--- a/src/lib/Libdis/disrsi_.c
+++ b/src/lib/Libdis/disrsi_.c
@@ -112,6 +112,15 @@ int disrsi_(
   if (dis_umaxd == 0)
     disiui_();
 
+  if (count >= dis_umaxd)
+    {
+    if (count > dis_umaxd)
+      goto overflow;
+
+    if (memcmp(scratch, dis_umax, dis_umaxd) > 0)
+      goto overflow;
+    }
+
   switch (c = (*dis_getc)(stream))
     {
 


### PR DESCRIPTION
Introduced an earlier check on the count variable. The existing code checks this too late and so can result in a buffer overflow.
