### PR TITLE
Update disrsi_.c

### DIFF
--- a/src/lib/Libdis/disrsi_.c
+++ b/src/lib/Libdis/disrsi_.c
@@ -40,6 +40,14 @@ int disrsi_(
   if (count > sizeof(scratch) - 1)
     return DIS_INVALID;
 
+  if (count > dis_umaxd)
+    goto overflow;
+  if (count == dis_umaxd)
+    {
+    if (memcmp(scratch, dis_umax, dis_umaxd) > 0)
+      goto overflow;
+    }
+
   switch (c = tcp_getc(chan))
     {
 


### PR DESCRIPTION
Introduced an earlier check on the count variable. The existing code checks this too late, in earlier Torque versions this can result in a buffer overflow - although this may not be the case in 4.x due to other code changes, best to play it safe.
