### PR TITLE
Run "make distcheck" as part of CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq check
 
-script: ./autogen.sh && ./configure --with-check && make && make check -k
+script: ./autogen.sh && ./configure --with-check && make && make check -k && make distcheck
 
 compiler:
   - clang


### PR DESCRIPTION
This change adds "make distcheck" as a step in the CI process.  This will help to weed out automake- and autoconf-related errors early.
