### PR TITLE
Fixed pam_pbssimpleauth.c to accept jobdir=<jobdir>

### DIFF
--- a/src/pam/pam_pbssimpleauth.c
+++ b/src/pam/pam_pbssimpleauth.c
@@ -86,8 +86,8 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     {
     if (!strcmp(*argv, "debug"))
       debug = 1;
-    else if (!strcmp(*argv, "jobdir"))
-      strncpy(jobdirpath, *argv, PATH_MAX);
+    else if (!strncmp(*argv, "jobdir=", 7))
+      strncpy(jobdirpath, (*argv)+7, PATH_MAX);
     else
       syslog(LOG_ERR, "unknown option: %s", *argv);
     }


### PR DESCRIPTION
If 'jobdir' is specified in pam configuration, pam_pbssimpleauth.c previously copied the string 'jobdir' over the compile-time default value of PBS_SERVER_HOME '/mom_priv/jobs'.

This change fixes it to copy the path part of a 'jobdir=<path to jobs>' pam configuration option in, for example, /etc/pam.d/password-auth, of the form:

account     required      pam_pbssimpleauth.so jobdir=/var/spool/torque/mom_priv/jobs
