### PR TITLE
TRQ-2250 Avoid trqauthd aborts

### DIFF
--- a/src/daemon_client/trq_auth_daemon.c
+++ b/src/daemon_client/trq_auth_daemon.c
@@ -290,7 +290,7 @@ int terminate_trqauthd()
     }
   else if ((rc = socket_write(sock, write_buf, strlen(write_buf))) < 0)
     {
-    fprintf(stderr, "Failed to send termnation request to trqauthd: %d\n", rc);
+    fprintf(stderr, "Failed to send termination request to trqauthd: %d\n", rc);
     }
   else if ((rc = socket_read_str(sock, &read_buf, &read_buf_len)) != PBSE_NONE)
     {
@@ -336,16 +336,16 @@ int trq_main(
   if (rc != PBSE_NONE)
     return(rc);
 
-  if (down_server == true)
-    {
-    rc = terminate_trqauthd();
-    return(rc);
-    }
-
   if (IamRoot() == 0)
     {
     printf("This program must be run as root!!!\n");
     return(PBSE_IVALREQ);
+    }
+
+  if (down_server == true)
+    {
+    rc = terminate_trqauthd();
+    return(rc);
     }
 
   if ((rc = load_config(&active_pbs_server, &trq_server_port, &daemon_port)) != PBSE_NONE)

--- a/src/lib/Libnet/server_core.c
+++ b/src/lib/Libnet/server_core.c
@@ -7,6 +7,7 @@
 #include <sys/un.h> /*sockaddr_un */
 #include <fcntl.h>
 #include <sys/stat.h> /* chmod */
+#include <signal.h> /* signal and constants */
 
 #include "pbs_error.h" /* PBSE_NONE */
 #include "log.h" /* log_event, PBSEVENT_JOB, PBS_EVENTCLASS_JOB */
@@ -183,6 +184,8 @@ int start_domainsocket_listener(
      before we can bind to it. Unlink it */
   unlink(socket_name);
 
+  /* Ignore SIGPIPE so a rogue client won't cause us to abort */
+  signal(SIGPIPE, SIG_IGN);
 
   if ( (listen_socket = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
     {


### PR DESCRIPTION
trqauthd does not handle SIGPIPE so a buggy/rogue client could
cause it to abort. Also, the new feature to shut down trqauthd
does not verify that the request comes from root.  These two
flaws could allow a denial of service attack.
