### PR TITLE
Changed hardcoded string lengths to strlen("...") for clarity.

### DIFF
--- a/src/pam/pam_pbssimpleauth.c
+++ b/src/pam/pam_pbssimpleauth.c
@@ -86,8 +86,8 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc,
     {
     if (!strcmp(*argv, "debug"))
       debug = 1;
-    else if (!strncmp(*argv, "jobdir=", 7))
-      strncpy(jobdirpath, (*argv)+7, PATH_MAX);
+    else if (!strncmp(*argv, "jobdir=", strlen("jobdir=")))
+      strncpy(jobdirpath, (*argv) + strlen("jobdir="), PATH_MAX);
     else
       syslog(LOG_ERR, "unknown option: %s", *argv);
     }


### PR DESCRIPTION
Strings being checked are still hard-coded but this makes the code clearer and reduces the chance of an error being made through missing a "magic number" change if the argument string being checked is changed for any reason.
