### PR TITLE
Fixed escaping of the special characters in the environment variables

### DIFF
--- a/src/cmds/common_cmds.c
+++ b/src/cmds/common_cmds.c
@@ -222,6 +222,7 @@ int parse_variable_list(
   char            name[JOB_ENV_START_SIZE];
   char           *s = NULL;
   char           *c = NULL;
+  char           *v = NULL;
   char           *delim = NULL;
 
   s = the_list;
@@ -254,9 +255,11 @@ int parse_variable_list(
 
       if (c != NULL)
         {
+        copy_env_value(mm, c, &v);
         append_dynamic_string(job_env, name);
         append_dynamic_string(job_env, "=");
-        append_dynamic_string(job_env, c);
+        append_dynamic_string(job_env, v);
+        memmgr_free(mm, v); v = NULL;
         if (delim == NULL)
           s = NULL;
         else


### PR DESCRIPTION
When I create simple script

``` sh
cat > testenv.sh <<EOF
#!/bin/sh
echo $TESTENV
EOF
```

and submit batch job with torque-4.2.4.2 qsub command

``` sh
TESTENV="first,second" qsub -q queue@torque -v TESTENV testenv.sh
```

than I'm getting only "first" in job standard output. I think this behavior is caused by missing copy_env_value function. This function escapes special characters that comes from environment variables (copy_env_value was used in the past, e.g. in torque 2.5.x qsub sources).
