### PR TITLE
Make sending e-mail more robust

### DIFF
--- a/src/server/svr_mail.c
+++ b/src/server/svr_mail.c
@@ -104,6 +104,13 @@
 #include "threadpool.h"
 #include "svrfunc.h" /* get_svr_attr_* */
 #include "work_task.h"
+#include <sys/wait.h>
+
+/* Unit tests should use the special unit test sendmail command */
+#ifdef UT_SENDMAIL_CMD
+#undef SENDMAIL_CMD
+#define SENDMAIL_CMD UT_SENDMAIL_CMD
+#endif
 
 /* External Functions Called */
 
@@ -112,8 +119,6 @@ extern void svr_format_job (FILE *, mail_info *, const char *);
 extern int  listening_socket;
 
 /* Global Data */
-#define TEMPORARY_FILE_LIFE_SPAN 15
-
 extern struct server server;
 
 extern int LOGLEVEL;
@@ -181,43 +186,21 @@ void add_body_info(
 
 
 /*
- * write_the_temporary_input_file()
+ * write_email()
  *
- * In emailing, the mail body is written as a temporary input file 
- * and then set up as the standard input for sendmail. This function
- * creates the temporary input file.
+ * In emailing, the mail body is written to a pipe connected to
+ * standard input for sendmail. This function supplies the body
+ * of the message.
  *
- * @post-cond: the temporary input file is created.
  */
-void write_the_temporary_input_file(
+void write_email(
 
-  const char *filename,
-  mail_info  *mi)
+  FILE      *outmail_input,
+  mail_info *mi)
 
   {
-  FILE  *outmail_input = fopen(filename, "w");
-  char  *bodyfmt = NULL;
+  char       *bodyfmt = NULL;
   const char *subjectfmt = NULL;
-  int         rc;
-
-  if (outmail_input == NULL)
-    {
-    char tmpBuf[LOG_BUF_SIZE];
-
-    snprintf(tmpBuf,sizeof(tmpBuf),
-      "Unable to fopen() file '%s' for writing: '%s' (error %d)\n",
-      filename,
-      strerror(errno),
-      errno);
-    log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
-      PBS_EVENTCLASS_JOB,
-      mi->jobid,
-      tmpBuf);
-
-    free_mail_info(mi);
-
-    return;
-    }
 
   /* Pipe in mail headers: To: and Subject: */
   fprintf(outmail_input, "To: %s\n", mi->mailto);
@@ -248,47 +231,16 @@ void write_the_temporary_input_file(
   /* Now pipe in the email body */
   svr_format_job(outmail_input, mi, bodyfmt);
 
-  errno = 0;
-  if ((rc = fclose(outmail_input)) != 0)
-    {
-    char tmpBuf[LOG_BUF_SIZE];
-
-    snprintf(tmpBuf,sizeof(tmpBuf),
-      "Creation of temporary input file '%s' failed: errno %d:%s\n",
-      filename, errno, strerror(errno));
-
-    log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
-      PBS_EVENTCLASS_JOB,
-      mi->jobid,
-      tmpBuf);
-    }
-  } /* write_the_temporary_input_file() */
+  } /* write_email() */
 
 
 /*
- * remove_temporary_file()
+ * send_the_mail()
  *
- * This task function can be used to remove any temporary file.
+ * In emailing, we fork and exec sendmail providing the body of
+ * the message on standard in.
  *
- * @post-cond: the temporary file is deleted
  */
-void remove_temporary_file(
-
-  struct work_task *ptask)
-
-  {
-  if (ptask->wt_parm1 != NULL)
-    {
-    unlink((char *)ptask->wt_parm1);
-    free(ptask->wt_parm1);
-    }
-
-  free(ptask->wt_mutex);
-  free(ptask);
-  } /* END remove_temporary_file() */
-
-
-
 void *send_the_mail(
 
   void *vp)
@@ -296,77 +248,147 @@ void *send_the_mail(
   {
   mail_info  *mi = (mail_info *)vp;
 
-  int         fd;
+  int         status;
+  int         numargs = 0;
+  int         pipes[2];
+  int         counter;
+  pid_t       pid;
+  char       *mailptr;
   const char *mailfrom = NULL;
-  char        tmp_input_filename[MAXLINE];
-  // We call sendmail with 3 arguments + 1 for null
-  char       *sendmail_args[4];
+  char        tmpBuf[LOG_BUF_SIZE];
+  // We call sendmail with cmd_name + 2 arguments + # of mailto addresses + 1 for null
+  char       *sendmail_args[100];
+  FILE       *stream;
 
-  snprintf(tmp_input_filename, sizeof(tmp_input_filename), "/tmp/%s%d",
-    mi->jobid, mi->mail_point);
 
-  if (fork())
-    {
-    /* let the child handle things */
-    set_task(WORK_Timed, time(NULL) + TEMPORARY_FILE_LIFE_SPAN, remove_temporary_file, 
-             strdup(tmp_input_filename), FALSE);
-    free_mail_info(mi);
-    return(NULL);
-    }
-
-  /* CHILD */
-
-  /* close all open network sockets */
-  net_close(-1);
-
-  // this socket isn't in the connections table so it doesn't get closed by net_close().
-  // the connections table has it marked as idle so it doesn't call close()
-  close(listening_socket);
-  
   /* Who is mail from, if SRV_ATR_mailfrom not set use default */
   get_svr_attr_str(SRV_ATR_mailfrom, (char **)&mailfrom);
   if (mailfrom == NULL)
     {
+    mailfrom = PBS_DEFAULT_MAIL;
     if (LOGLEVEL >= 5)
       {
       char tmpBuf[LOG_BUF_SIZE];
 
       snprintf(tmpBuf,sizeof(tmpBuf),
-        "Updated mailto from user list: '%s'\n",
-        mi->mailto);
+        "Updated mailfrom to default: '%s'\n",
+        mailfrom);
       log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
         PBS_EVENTCLASS_JOB,
         mi->jobid,
         tmpBuf);
       }
-
-    mailfrom = PBS_DEFAULT_MAIL;
     }
 
-  write_the_temporary_input_file(tmp_input_filename, mi);
+  sendmail_args[numargs++] = (char *)SENDMAIL_CMD;
+  sendmail_args[numargs++] = (char *)"-f";
+  sendmail_args[numargs++] = (char *)mailfrom;
 
-  sendmail_args[0] = strdup("-f");
-  sendmail_args[1] = strdup(mailfrom);
-  sendmail_args[2] = strdup(mi->mailto);
-  sendmail_args[3] = NULL;
-    
-  free_mail_info(mi);
-
-  if ((fd = open(tmp_input_filename, O_RDONLY)) >= 0)
+  /* Add the e-mail addresses to the command line */
+  mailptr = strdup(mi->mailto);
+  sendmail_args[numargs++] = mailptr;
+  for (counter=0; counter < (int)strlen(mailptr); counter++)
     {
-    // make sure that we're > 3 at this point 
-    FDMOVE(fd);
-
-    // make this stdin for the job
-    close(0);
-
-    dup(fd);
-
-    execv(SENDMAIL_CMD, sendmail_args);
+    if (mailptr[counter] == ',')
+      {
+      mailptr[counter] = '\0';
+      sendmail_args[numargs++] = mailptr + counter + 1;
+      if (numargs >= 99)
+        break;
+      }
     }
 
-  exit(0);
-  
+  sendmail_args[numargs] = NULL;
+
+  /* Create a pipe to talk to the sendmail process we are about to fork */
+  if (pipe(pipes) == -1)
+    {
+    snprintf(tmpBuf, sizeof(tmpBuf), "Unable to pipes for sending e-mail\n");
+    log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
+      PBS_EVENTCLASS_JOB,
+      mi->jobid,
+      tmpBuf);
+
+    free_mail_info(mi);
+    free(mailptr);
+    return(NULL);
+    }
+
+  if ((pid=fork()) == -1)
+    {
+    snprintf(tmpBuf, sizeof(tmpBuf), "Unable to fork for sending e-mail\n");
+    log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
+      PBS_EVENTCLASS_JOB,
+      mi->jobid,
+      tmpBuf);
+
+    free_mail_info(mi);
+    free(mailptr);
+    close(pipes[0]);
+    close(pipes[1]);
+    return(NULL);
+    }
+  else if (pid == 0)
+    {
+    /* CHILD */
+
+    /* close all open network sockets */
+    net_close(-1);
+
+    // this socket isn't in the connections table so it doesn't get closed by net_close().
+    // the connections table has it marked as idle so it doesn't call close()
+    close(listening_socket);
+
+    /* Close the write end of the pipe, make read end stdin */
+    dup2(pipes[0],STDIN_FILENO);
+    close(pipes[0]);
+    close(pipes[1]);
+    execv(SENDMAIL_CMD, sendmail_args);
+    /* This never returns, but if the execv fails the child should exit */
+    exit(1);
+    }
+  else
+    {
+    /* This is the parent */
+
+    /* Close the read end of the pipe */
+    close(pipes[0]);
+
+    /* Write the body to the pipe */
+    stream = fdopen(pipes[1], "w");
+    write_email(stream, mi);
+
+    /* Close and wait for the command to finish */
+    if (fclose(stream) != 0)
+      {
+      snprintf(tmpBuf,sizeof(tmpBuf),
+        "Piping mail body to sendmail closed: errno %d:%s\n",
+        errno, strerror(errno));
+
+      log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
+        PBS_EVENTCLASS_JOB,
+        mi->jobid,
+        tmpBuf);
+      }
+    waitpid(pid, &status, 0);
+
+    if (status != 0)
+      {
+      snprintf(tmpBuf,sizeof(tmpBuf),
+        "Sendmail command returned %d. Mail may not have been sent\n",
+        status);
+
+      log_event(PBSEVENT_ERROR | PBSEVENT_ADMIN | PBSEVENT_JOB,
+        PBS_EVENTCLASS_JOB,
+        mi->jobid,
+        tmpBuf);
+      }
+      
+    free_mail_info(mi);
+    free(mailptr);
+    return(NULL);
+    }
+    
   /* NOT REACHED */
 
   return(NULL);
@@ -559,10 +581,11 @@ void svr_mailowner(
         if ((strlen(mailto) + strlen(pas->as_string[i]) + 2) < sizeof(mailto))
           {
           strcat(mailto, pas->as_string[i]);
-          strcat(mailto, " ");
+          strcat(mailto, ",");
           }
         }
       }
+      mailto[strlen(mailto)] = '\0';
     }
   else
     {

--- a/src/server/test/svr_mail/Makefile.am
+++ b/src/server/test/svr_mail/Makefile.am
@@ -1,6 +1,6 @@
 PROG_ROOT = ../..
 
-AM_CFLAGS = -g -DTEST_FUNCTION -I${PROG_ROOT}/ --coverage `xml2-config --cflags`
+AM_CFLAGS = -g -DTEST_FUNCTION -DUT_SENDMAIL_CMD=\"./fakemail.sh\" -I${PROG_ROOT}/ --coverage `xml2-config --cflags`
 AM_LIBS = `xml2-config --libs`
 
 lib_LTLIBRARIES = libsvr_mail.la

--- a/src/server/test/svr_mail/fakemail.sh
+++ b/src/server/test/svr_mail/fakemail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Simple script to impersonate sendmail but
+# write to a file in /tmp instead of actually
+# mailing the message
+
+MAILFILE=/tmp/mail.out
+MAILFROM=$2
+shift 2
+MAILTO="$@"
+
+echo "MAILFROM=$MAILFROM" > $MAILFILE
+echo "MAILTO=$MAILTO" >> $MAILFILE
+echo >> $MAILFILE
+cat >> $MAILFILE

--- a/src/server/test/svr_mail/test_svr_mail.c
+++ b/src/server/test/svr_mail/test_svr_mail.c
@@ -68,7 +68,7 @@ START_TEST(test_with_default_files_when_complete)
   snprintf(correct_errfilepath, sizeof(correct_errfilepath), "Error_Path: %s", errpath);
   svr_mailowner(&pjob, MAIL_END, MAIL_NORMAL, mailbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)
@@ -89,7 +89,7 @@ START_TEST(test_with_default_files_when_complete)
 
   svr_mailowner_with_message(&pjob, MAIL_END, MAIL_NORMAL, mailbuf,msgbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)
@@ -133,7 +133,7 @@ START_TEST(test_with_oe_when_complete)
   snprintf(correct_errfilepath, sizeof(correct_errfilepath), "Error_Path: %s", outpath);
   svr_mailowner(&pjob, MAIL_END, MAIL_NORMAL, mailbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)
@@ -154,7 +154,7 @@ START_TEST(test_with_oe_when_complete)
 
   svr_mailowner_with_message(&pjob, MAIL_END, MAIL_NORMAL, mailbuf,msgbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)
@@ -199,7 +199,7 @@ START_TEST(test_with_eo_when_complete)
   snprintf(correct_errfilepath, sizeof(correct_errfilepath), "Error_Path: %s", errpath);
   svr_mailowner(&pjob, MAIL_END, MAIL_NORMAL, mailbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)
@@ -220,7 +220,7 @@ START_TEST(test_with_eo_when_complete)
 
   svr_mailowner_with_message(&pjob, MAIL_END, MAIL_NORMAL, mailbuf,msgbuf);
   fp = fopen("/tmp/mail.out", "r");
-  /* if fp is null, no email program was set hence no test */
+  fail_unless((fp != NULL), "No output file was found");
   if (fp)
     {
     while (fgets(buf, sizeof(buf), fp) != NULL)


### PR DESCRIPTION
- Use pipes instead of temporary files to pass the content to sendmail
- Use comma as a delimiter for 'To:' addresses per RFC2822
- exec-like functions expect the first argument to be the name of the program
- Provide multiple addresses to sendmail in separate arguments
- Update the unit test to write to a temp file so it can check the content
