### PR TITLE
Prevent sendmail hangs due to unclosed pipes

### DIFF
--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -1144,24 +1144,6 @@ void net_close(
 
 
 
-/*
- * performs the work of net_close but without worrying about mutexes.
- * It can do this because this function should only ever be called by a child that
- * is simply closing all of the file descriptors.
- *
- * WARNING!!!: Only call from forked children ONLY ONLY ONLY
- */
-void net_close_without_mutexes()
-
-  {
-  for (int i = 0; i < max_connection; i++)
-    {
-    if (svr_conn[i].cn_active != Idle)
-      close(i);
-    }
-  }
-
-
 
 /*
  * get_connectaddr - return address of host connected via the socket

--- a/src/server/test/svr_mail/scaffolding.c
+++ b/src/server/test/svr_mail/scaffolding.c
@@ -25,8 +25,6 @@ pthread_mutex_t *svr_do_schedule_mutex;
 pthread_mutex_t *listener_command_mutex;
 int listening_socket;
 
-void net_close_without_mutexes() {}
-
 int LOGLEVEL = 7; /* force logging code to be exercised as tests run */
 
 int enqueue_threadpool_request(void *(*func)(void *),void *arg)


### PR DESCRIPTION
The problem was that multiple threads sending mail at the same time would "share" their pipes with _all_ the children being forked.  This ensures _all_ file descriptors (except the read pipe) is closed, including the log file and network connections.
