### PR TITLE
Allow building of RPMs from git archive output

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -89,7 +89,7 @@ Source: http://www.clusterresources.com/downloads/torque/%{name}-%{tarversion}.t
 Vendor: %{?_vendorinfo:%{_vendorinfo}}%{!?_vendorinfo:%{_vendor}}
 Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
 #BuildSuggests: openssh-clients tcl-devel tclx tk-devel
-BuildRequires: %{breq_gui} %{breq_munge} %{breq_pam} %{breq_scp} make
+BuildRequires: %{breq_gui} %{breq_munge} %{breq_pam} %{breq_scp} make libtool automake openssl-devel libxml2-devel boost-devel
 Conflicts: pbspro, openpbs, openpbs-oscar
 Obsoletes: scatorque <= %{version}-%{release}, %{!?with_gui:%{name}-gui < %{version}-%{release}}
 Provides: pbs, pbs-docs, pbs-pam, %{!?with_gui:%{name}-gui = %{version}-%{release}}
@@ -177,6 +177,7 @@ CFLAGS="%{?cflags:%{cflags}}%{!?cflags:$RPM_OPT_FLAGS}"
 CXXFLAGS="%{?cxxflags:%{cxxflags}}%{!?cxxflags:$RPM_OPT_FLAGS}"
 export CFLAGS CXXFLAGS
 
+./autogen.sh
 %configure --includedir=%{_includedir}/%{name} --with-default-server=%{torque_server} \
     --with-server-home=%{torque_home} %{ac_with_debug} %{ac_with_libcpuset} \
     --with-sendmail=%{sendmail_path} %{ac_with_numa} %{ac_with_memacct} %{ac_with_top} \


### PR DESCRIPTION
This patch allows rpmbuild to make RPMs for RHEL6 using the torque.spec file from the repo, by:
1) Adding a call to autogen.sh before %configure macro
2) Adding BuildRequires for the autogen.sh script and the Torque binaries

Tested on FC19 by cloning the repo, building the .spec file with "./autogen.sh && configure", then using the .spec file and the git archive artefact to build the SRPM ("rpmbuild -bs torque.spec"), then using mock to build the SRPM into the RPMs in a RHEL6 environment.
