### PR TITLE
pbs_mom init scripts use the pbs_mom lock file as pid file

### DIFF
--- a/contrib/init.d/pbs_mom.in
+++ b/contrib/init.d/pbs_mom.in
@@ -53,7 +53,7 @@ case "$1" in
 	start)
 		echo -n "Starting TORQUE Mom: "
 		# check if pbs_mom is already running
-		status pbs_mom 2>&1 > /dev/null
+		status -p $PBS_HOME/mom_priv/mom.lock pbs_mom 2>&1 > /dev/null
 		RET=$?
 		[ $RET -eq 0 ] && echo -n "pbs_mom already running" && success && echo && exit 0
 
@@ -74,7 +74,7 @@ case "$1" in
 	stop)
 		echo -n "Shutting down TORQUE Mom: "
 		# check if pbs_mom is running
-		status pbs_mom 2>&1 > /dev/null
+		status -p $PBS_HOME/mom_priv/mom.lock pbs_mom 2>&1 > /dev/null
 		RET=$?
 		[ ! $RET -eq 0 ] && echo -n "pbs_mom already stopped" && success && echo && exit 0
 
@@ -85,7 +85,7 @@ case "$1" in
 		rm -f /var/lock/subsys/pbs_mom
 		;;
 	status)
-		status pbs_mom
+		status -p $PBS_HOME/mom_priv/mom.lock pbs_mom
 		RET=$?
 		;;
 	restart)


### PR DESCRIPTION
When an interactive job is running, multiple pbs_mom children are spawned. If the parent pbs_mom fails or is killed (eg during service restart), service start fails because the child pbs_moms are seen as active pbs_mom parent process.
Using the lock file that contains the pid to check the status fixes this problem. 

remark: i have no clue when `status -p <pidfile>` was introduced in the init functions (it's available in at least EL5.8 and EL6.4).
