### PR TITLE
TRQ-2410: qstat bad jobid

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -3284,7 +3284,7 @@ int main(
        break;
 
       }    /* END switch (mode) */
-    if (any_failed != PBSE_NONE)
+    if ((ret_code == PBSE_NONE) && (any_failed != PBSE_NONE))
       {
         ret_code = any_failed;
       }


### PR DESCRIPTION
qstat does not interrupt the process of parsing in spite of the errors that occur during getting info. Returns first non-zero err code, if error has occurred. Or returns zero otherwise.
