### PR TITLE
TRQ-2411: print the header only once

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -121,6 +121,7 @@ string get_err_msg(
   {
   char* errmsg = pbs_geterrmsg(connect);
   string msg;
+  char any_failed_str[16];
   if (errmsg != NULL)
     {
     msg = string("qstat: ") + string(errmsg) + " ";
@@ -128,10 +129,11 @@ string get_err_msg(
     }
   else
     {
-    msg = string("qstat: Error (%d - ",any_failed)
-      + string(pbs_strerror(any_failed))
+    sprintf(any_failed_str, "%d", any_failed);
+    msg = string("qstat: Error (") + string(any_failed_str) + string(" - ")
+      + string(pbs_strerror(any_failed)) + string(") ")
       + string("getting status of ")
-      + string(mode);
+      + string(mode) + string(" ");
     }
   msg.append(id);
   return msg;

--- a/src/cmds/qstat.h
+++ b/src/cmds/qstat.h
@@ -1,6 +1,7 @@
 #include "license_pbs.h" /* See here for the software license */
 
 #include "pbs_ifl.h" /* batch_status */
+#include <string>
 
 int isjobid(const char *string);
 
@@ -12,11 +13,11 @@ int process_commandline_opts(int, char **, int *, int *);
 
 void get_ct(const char *, int *, int *);
  
-int run_job_mode(bool, const char *, int *, char *, char *, char *, char *, char *);
+int run_job_mode(bool, const char *, int *, char *, char *, char *, char *, char *, std::string&);
 
-int run_queue_mode(bool, const char *, char *, char *, char *);
+int run_queue_mode(bool, const char *, char *, char *, char *, std::string&);
 
-int run_server_mode(bool, const char *, char *);
+int run_server_mode(bool, const char *, char *, std::string&);
 
 /* static void states(char *string, char *q, char *r, char *h, char *w, char *t, char *e, int len); */
 
@@ -52,4 +53,9 @@ int tcl_stat(char *type, struct batch_status *bs, int f_opt);
 
 void tcl_run(int f_opt);
 
+std::string get_err_msg(
+  int   any_failed,
+  const char *mode,
+  int   connect,
+  char *id);
 /* main */

--- a/src/cmds/test/qstat/scaffolding.c
+++ b/src/cmds/test/qstat/scaffolding.c
@@ -8,15 +8,15 @@
 
 #define ISNAMECHAR(x) ( (isgraph(x)) && ((x) != '#') && ( (x) != '@') )
 
-int pbs_errno = 0;
+int pbs_errno = PBSE_NONE;
 char *pbs_server = NULL;
+const char* default_err_msg = "err message for test qstat";
 
 bool connect_success = true;
 
 char *pbs_geterrmsg(int connect)
-  { 
-  fprintf(stderr, "The call to pbs_geterrmsg needs to be mocked!!\n");
-  return(PBSE_NONE);
+  {
+  return((pbs_errno == PBSE_NONE)? NULL : strdup(default_err_msg));
   }
 
 struct batch_status * pbs_selstat(int c, struct attropl *attrib, char *extend)
@@ -383,8 +383,7 @@ void set_attr(
 
 char *pbs_strerror(int err)
   { 
-  fprintf(stderr, "The call to pbs_strerror needs to be mocked!!\n");
-  return(PBSE_NONE);
+  return((err == PBSE_NONE)? NULL : strdup(default_err_msg));
   }
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Changes:
- added global variable print_header for indication "need print header"

Tests demonstrating how it behaves in fixed version
$ src/cmds/.libs/qstat 53 52 54
Job ID                    Name             User            Time Use S Queue

---

53.host                     STDIN            user                  0 Q batch
qstat: Unknown Job Id Error 52.host
54.host                     STDIN            user                  0 Q batch

e.g. 52 is incorrect JobId
