### PR TITLE
TRQ-2845: Fixed tmp_time math in mom_main main loop

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -5861,6 +5861,23 @@ void prepare_child_tasks_for_delete()
 
 
 
+time_t calculate_select_timeout() {
+  time_t tmpTime;
+  extern time_t wait_time;
+
+  tmpTime = MIN(wait_time, (LastServerUpdateTime + ServerStatUpdateInterval) - time_now);
+
+  tmpTime = MIN(tmpTime, (last_poll_time + CheckPollTime) - time_now);
+
+  tmpTime = MAX(1, tmpTime);
+
+  if (LastServerUpdateTime == 0)
+    tmpTime = 1;
+
+  return tmpTime;
+}
+
+
 
 /**
  * main_loop
@@ -5871,7 +5888,6 @@ void prepare_child_tasks_for_delete()
 void main_loop(void)
 
   {
-  extern time_t wait_time;
   double        myla;
   time_t        tmpTime;
 #ifdef USESAVEDRESOURCES
@@ -5983,14 +5999,7 @@ void main_loop(void)
 
     time_now = time((time_t *)0);
 
-    tmpTime = MIN(wait_time, time_now - (LastServerUpdateTime + ServerStatUpdateInterval));
-
-    tmpTime = MIN(tmpTime, time_now - (last_poll_time + CheckPollTime));
-
-    tmpTime = MAX(1, tmpTime);
-
-    if (LastServerUpdateTime == 0)
-      tmpTime = 1;
+    tmpTime = calculate_select_timeout();
 
     resend_things();
 

--- a/src/resmom/test/mom_main/test_mom_main.c
+++ b/src/resmom/test/mom_main/test_mom_main.c
@@ -11,9 +11,14 @@ extern bool parsing_hierarchy;
 extern bool received_cluster_addrs;
 extern char *path_mom_hierarchy;
 extern int  MOMJobDirStickySet;
+extern time_t time_now;
+extern time_t wait_time;
+extern time_t LastServerUpdateTime;
+extern time_t last_poll_time;
 
 void read_mom_hierarchy();
 int  parse_integer_range(const char *range_str, int &start, int &end);
+time_t calculate_select_timeout();
 
 
 START_TEST(test_read_mom_hierarchy)
@@ -101,6 +106,75 @@ START_TEST(test_mom_job_dir_sticky_config)
 END_TEST
 
 
+/**
+ * time_t calculate_select_timeout(void)
+ * Input:
+ *  (G) time_t time_now - periodically updated current time.
+ *  (G) time_t wait_time - constant systme-dependent value.
+ *  (G) time_t LastServerUpdateTime - last status update timestamp.
+ *  (G) int ServerStatUpdateInterval - status update interval.
+ *  (G) time_t last_poll_time - last poll timestamp.
+ *  (G) int CheckPollTime - poll interval.
+ */
+START_TEST(calculate_select_timeout_test)
+  {
+  /* wait time is minimum */
+  time_now = 110;
+  wait_time = 9;
+  LastServerUpdateTime = 100;
+  ServerStatUpdateInterval = 20; /* 10 seconds till the next status update */
+  last_poll_time = 90;
+  CheckPollTime = 30; /* 10 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 9);
+
+  /* status update is minimum */
+  time_now = 110;
+  wait_time = 10;
+  LastServerUpdateTime = 100;
+  ServerStatUpdateInterval = 19; /* 9 seconds till the next status update */
+  last_poll_time = 90;
+  CheckPollTime = 30; /* 10 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 9);
+
+  /* poll is minimum */
+  time_now = 110;
+  wait_time = 10;
+  LastServerUpdateTime = 100;
+  ServerStatUpdateInterval = 20; /* 10 seconds till the next status update */
+  last_poll_time = 90;
+  CheckPollTime = 29; /* 9 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 9);
+
+  /* LastServerUpdateTime is zero */
+  time_now = 110;
+  wait_time = 10;
+  LastServerUpdateTime = 0;
+  ServerStatUpdateInterval = 20;
+  last_poll_time = 90;
+  CheckPollTime = 30; /* 10 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 1);
+
+  /* status update is minimum and was needed to be sent some time ago */
+  time_now = 110;
+  wait_time = 10;
+  LastServerUpdateTime = 89;
+  ServerStatUpdateInterval = 20; /* -1 seconds till the next status update */
+  last_poll_time = 90;
+  CheckPollTime = 30; /* 10 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 1);
+
+  /* poll is minimum and was needed to be sent some time ago */
+  time_now = 110;
+  wait_time = 10;
+  LastServerUpdateTime = 100;
+  ServerStatUpdateInterval = 20; /* 10 seconds till the next status update */
+  last_poll_time = 79;
+  CheckPollTime = 30; /* -1 seconds till the next poll */
+  fail_unless(calculate_select_timeout() == 1);
+  }
+END_TEST
+
+
 Suite *mom_main_suite(void)
   {
   Suite *s = suite_create("mom_main_suite methods");
@@ -111,6 +185,10 @@ Suite *mom_main_suite(void)
   tc_core = tcase_create("test_mom_job_dir_sticky_config");
   tcase_add_test(tc_core, test_mom_job_dir_sticky_config);
   tcase_add_test(tc_core, test_parse_integer_range);
+  suite_add_tcase(s, tc_core);
+
+  tc_core = tcase_create("calculate_select_timeout_test");
+  tcase_add_test(tc_core, calculate_select_timeout_test);
   suite_add_tcase(s, tc_core);
 
   return s;


### PR DESCRIPTION
Fixed tmp_time math
Moved the logic to a testable function
Wrote a unit test

NOTE: please take care about mom_main.c:5868: if TRQ-2761 would be merged the line have to use the calculate_select_timeout() function in place of ServerStatUpdateInterval in this line:
-  tmpTime = MIN(wait_time, (LastServerUpdateTime + ServerStatUpdateInterval) - time_now);
-  tmpTime = MIN(wait_time, (LastServerUpdateTime + calculate_select_timeout()) - time_now);
