### PR TITLE
TRQ-2509: Properly handle basic shell syntax in qsub script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ src/cmds/test/qstart/test_qstart
 src/cmds/test/qstat/test_qstat
 src/cmds/test/qstop/test_qstop
 src/cmds/test/qsub_functions/build_test_files.sh
-src/cmds/test/qsub_functions/test_x11_get_proto
+src/cmds/test/qsub_functions/test_qsub_functions
 src/cmds/test/qterm/test_qterm
 src/daemon_client/test/trq_auth_daemon/test_trq_auth_daemon
 src/lib/Libattr/test/attr_atomic/test_attr_atomic

--- a/src/cmds/qsub_functions.c
+++ b/src/cmds/qsub_functions.c
@@ -1265,16 +1265,25 @@ static int get_script(
 
 
 
-
-
+/**
+ * Parse given character string in shell format to arc/argv format adding "qsub" as a first argument
+ * making it look like qsub was called from command line.
+ *
+ * This function handles quotes and escape symbols as shell does:
+ *  - arguments are splitted by any number of space characters as defined by isspace()
+ *  - unescaped quotes enclose a single argument or its part. Quotes are dropped.
+ *  - escaped characters treated as is: escaped quote and spaces are treated as a character without
+ *    any special meaning
+ */
 void make_argv(
 
-  int  *argc,
-  char *argv[],
-  char *line)
+  int        *argc,   /* O - result argc value */
+  char       *argv[], /* O - result argv value */
+  char const *line)   /* I - input cmdline shell string */
 
   {
-  char *l, *b, *c, *buffer;
+  char const *l, *c;
+  char *b, *buffer;
   int len;
   char quote;
 
@@ -1304,8 +1313,8 @@ void make_argv(
     if ((*c == '"') || (*c == '\''))
       {
       quote = *c;
-      /* we need to include the quotes in what is passed on */
-      *b++ = *c++;
+      /* don't include the quotes */
+      c++;
 
       while ((*c != quote) && *c)
         *b++ = *c++;
@@ -1318,7 +1327,8 @@ void make_argv(
         exit(1);
         }
 
-      *b++ = *c++;
+      /* don't include the quotes */
+      c++;
       }
     else if (*c == '\\')
       {
@@ -1400,9 +1410,10 @@ void do_dir(
   {
   int argc = 0;
 
-  static char *vect[MAX_ARGV_LEN + 1];
-
-  memset(&vect, 0, MAX_ARGV_LEN + 1);
+  /* initialize all vect pointers with NULLs.
+   * make_argv() frees an item if it's non-NULL and then allocates memory for a new one.
+   */
+  static char *vect[MAX_ARGV_LEN + 1] = {};
 
   make_argv(&argc, vect, opts);
 

--- a/src/cmds/qsub_functions.h
+++ b/src/cmds/qsub_functions.h
@@ -175,7 +175,7 @@ void post_check_attributes(job_info *ji,char *script_tmp);
 void make_argv(
     int  *argc,
     char *argv[],
-    char *line);
+    char const *line);
 
 void do_dir(
     char *opts,

--- a/src/cmds/test/Makefile.am
+++ b/src/cmds/test/Makefile.am
@@ -1,7 +1,6 @@
 #Files that are used for wrappers in order to test the code.
 #qsub wraps qsub_functions
-#CHECK_DIRS = MXML common_cmds pbs_track pbsdsh pbsnodes pbspd pbspoe qalter qchkpt qdel qdisable qenable qgpumode qgpureset qhold qmgr qmove qmsg qorder qrerun qrls qrun qselect qsig qstart qstat qstop qsub_functions qterm
-CHECK_DIRS = MXML common_cmds pbs_track pbsdsh pbsnodes pbspd pbspoe qalter qchkpt qdel qdisable qenable qgpumode qgpureset qhold qmgr qmove qmsg qorder qrerun qrls qrun qselect qsig qstart qstat qstop qterm
+CHECK_DIRS = MXML common_cmds pbs_track pbsdsh pbsnodes pbspd pbspoe qalter qchkpt qdel qdisable qenable qgpumode qgpureset qhold qmgr qmove qmsg qorder qrerun qrls qrun qselect qsig qstart qstat qstop qsub_functions qterm
 
 $(CHECK_DIRS)::
 	$(MAKE) -C $@ $(MAKECMDGOALS)

--- a/src/cmds/test/qsub_functions/scaffolding.c
+++ b/src/cmds/test/qsub_functions/scaffolding.c
@@ -8,6 +8,7 @@
 
 int pbs_errno = 0; 
 char *pbs_server = NULL;
+bool exit_called = false;
 
 
 char *pbs_geterrmsg(int connect)
@@ -16,7 +17,7 @@ char *pbs_geterrmsg(int connect)
   exit(1);
   }
 
-int hash_find(job_data *head, const char *name, job_data **env_var)
+int hash_find(job_data_container *head, const char *name, job_data **env_var)
   {
   fprintf(stderr, "The call to hash_find to be mocked!!\n");
   exit(1);
@@ -206,22 +207,6 @@ char *pbs_default(void)
   exit(1);
   }
 
-int pbs_submit_hash(
-
-  int                 socket,
-  job_data_container *job_attr,
-  job_data_container *res_attr,
-  char               *script,
-  char               *destination,
-  char               *extend,  /* (optional) */
-  char               **return_jobid,
-  char               **msg)
-
-  {
-  fprintf(stderr, "The call to pbs_submit_hash to be mocked!!\n");
-  exit(1);
-  }
-
 int get_fullhostname( char *shortname,  char *namebuf,  int bufsize,  char *EMsg) 
   {
   fprintf(stderr, "The call to get_fullhostname to be mocked!!\n");
@@ -241,13 +226,29 @@ int cnt2server(const char *SpecServer)
   }
 }
 
-int hash_count(job_data *head)
+int pbs_submit_hash(
+
+  int                 socket,
+  job_data_container *job_attr,
+  job_data_container *res_attr,
+  char               *script,
+  char               *destination,
+  char               *extend,  /* (optional) */
+  char               **return_jobid,
+  char               **msg)
+
+  {
+  fprintf(stderr, "The call to pbs_submit_hash to be mocked!!\n");
+  exit(1);
+  }
+
+int hash_count(job_data_container *head)
   {
   fprintf(stderr, "The call to hash_count to be mocked!!\n");
   exit(1);
   }
 
-int hash_strlen(job_data *src)
+int hash_strlen(job_data_container *src)
   {
   fprintf(stderr, "The call to hash_strlen to be mocked!!\n");
   exit(1);
@@ -276,4 +277,10 @@ ssize_t write_ac_socket(int fd, const void *buf, ssize_t count)
 ssize_t read_ac_socket(int fd, void *buf, ssize_t count)
   {
   return(0);
+  }
+
+char *get_trq_param(const char *param, const char *config_buf)
+  {
+  fprintf(stderr, "The call to get_trq_param to be mocked!!\n");
+  exit(1);
   }

--- a/src/cmds/test/qsub_functions/test_qsub_functions.c
+++ b/src/cmds/test/qsub_functions/test_qsub_functions.c
@@ -1,6 +1,11 @@
 
-#include "test_qsub_functions.h"
+/*
+ * This have to be included here, before check.h because it defines a function check() as a macro
+ * that breaks STL basic_ios.h class definition
+ */
 #include "qsub_functions.h"
+
+#include "test_qsub_functions.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -47,6 +52,43 @@ START_TEST(test_isWindowsFormat)
   }
 END_TEST
 
+START_TEST(test_make_argv)
+  {
+#define MAX_ARGV_LEN 16
+  int argc;
+  char *vect[MAX_ARGV_LEN + 1] = {};
+
+  /* 0: "qsub"         1            2                3                     4    5    6   7 8 */
+  char const * line = "simple_arg \"quoted ' arg\" \'s\"quoted \" arg\' \\\\ \\\" \\\' \\  end";
+  make_argv(&argc, vect, line);
+  fail_unless(argc == 9);
+  fail_unless(strcmp(vect[0], "qsub") == 0);
+  fail_unless(strcmp(vect[1], "simple_arg") == 0);
+  fail_unless(strcmp(vect[2], "quoted ' arg") == 0);
+  fail_unless(strcmp(vect[3], "s\"quoted \" arg") == 0);
+  fail_unless(strcmp(vect[4], "\\") == 0);
+  fail_unless(strcmp(vect[5], "\"") == 0);
+  fail_unless(strcmp(vect[6], "\'") == 0);
+  fail_unless(strcmp(vect[7], " ") == 0);
+  fail_unless(strcmp(vect[8], "end") == 0);
+  fail_unless(vect[9] == NULL);
+
+  /* two args that are (escaped) spaces + test mem free/alloc no-fail test */
+  line = "\\  \\\t";
+  make_argv(&argc, vect, line);
+  fail_unless(argc == 3);
+  fail_unless(strcmp(vect[0], "qsub") == 0);
+  fail_unless(strcmp(vect[1], " ") == 0);
+  fail_unless(strcmp(vect[2], "\t") == 0);
+
+  /* no arguments + mem free/alloc no-fail test */
+  line = "      \t     ";
+  make_argv(&argc, vect, line);
+  fail_unless(argc == 1);
+  fail_unless(strcmp(vect[0], "qsub") == 0);
+  }
+END_TEST
+
 Suite *qsub_functions_suite(void)
   {
   Suite *s = suite_create("qsub_functions methods");
@@ -56,6 +98,10 @@ Suite *qsub_functions_suite(void)
 
   tc_core = tcase_create("test isWindowsFormat");
   tcase_add_test(tc_core, test_isWindowsFormat);
+  suite_add_tcase(s, tc_core);
+
+  tc_core = tcase_create("test_make_argv");
+  tcase_add_test(tc_core, test_make_argv);
   suite_add_tcase(s, tc_core);
 
   return s;


### PR DESCRIPTION
- properly (as shell does) handle quotations in qsub script #PBS
  arguments in make_argv()
- fixed wrong static buffer operations in do_dir()
- fixed and re-enabled qsub_functions() unit tests
- wrote make_argv() unit test
