### PR TITLE
Changed .spec-file to allow building RPMs with custom trqauthd-sock-dir

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -47,6 +47,7 @@
 %define ac_with_scp        --with-rcp=%{?with_scp:scp}%{!?with_scp:pbs_rcp}
 %define ac_with_spool      --%{?with_spool:en}%{!?with_spool:dis}able-spool
 %define ac_with_syslog     --%{?with_syslog:en}%{!?with_syslog:dis}able-syslog
+%define ac_trqauthd_sock_dir %{?trqauthd_sock_dir:%{trqauthd_sock_dir}}%{!?trqauthd_sock_dir:/tmp}
 
 ### Build Requirements
 %define breq_cpuset   %{?with_cpuset:hwloc-devel}
@@ -184,6 +185,7 @@ export CFLAGS CXXFLAGS
 %configure --includedir=%{_includedir}/%{name} --with-default-server=%{torque_server} \
     --with-server-home=%{torque_home} %{ac_with_debug} %{ac_with_libcpuset} \
     --with-sendmail=%{sendmail_path} %{ac_with_numa} %{ac_with_memacct} %{ac_with_top} \
+    --with-trqauthd-sock-dir=%{ac_trqauthd_sock_dir} \
     --disable-dependency-tracking %{ac_with_gui} %{ac_with_scp} %{ac_with_syslog} \
     --disable-gcc-warnings %{ac_with_munge} %{ac_with_pam} %{ac_with_drmaa} \
     --disable-qsub-keep-override %{ac_with_blcr} %{ac_with_cpuset} %{ac_with_spool} %{?acflags}


### PR DESCRIPTION
As discussed on torquedev mailing list; this patch to the torque.spec allows building of Torque RPM's with a custom trqauthd-sock-dir.

It defines a variables to be specified via the command line:
rpmbuild -ba --define 'trqauthd_sock_dir /var/run' ./torque.spec

This in turn results in rpmbuild calling configure appropriately:
./configure --with-trqauthd-sock-dir=/var/run

If not defined it will default back to /tmp