### PR TITLE
remtree: don't skip files that start with two dots (exact match on '..')

### DIFF
--- a/src/resmom/mom_job_func.c
+++ b/src/resmom/mom_job_func.c
@@ -314,9 +314,9 @@ int remtree(
 
     while ((pdir = readdir(dir)) != NULL)
       {
-        if (pdir->d_name[0] == '.' && (pdir->d_name[1] == '\0' ||
-           (pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')))
-        continue;
+      if (pdir->d_name[0] == '.' && (pdir->d_name[1] == '\0' ||
+         (pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')))
+      continue;
 
       snprintf(namebuf + len, sizeof(namebuf) - len, "%s", pdir->d_name);
 

--- a/src/resmom/mom_job_func.c
+++ b/src/resmom/mom_job_func.c
@@ -314,8 +314,8 @@ int remtree(
 
     while ((pdir = readdir(dir)) != NULL)
       {
-      if ((pdir->d_name[0] == '.') &&
-          ((pdir->d_name[1] == '\0') || (pdir->d_name[1] == '.')))
+      if (pdir->d_name[0] == '.' && pdir->d_name[1] == '\0' ||
+	  pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')
         continue;
 
       snprintf(namebuf + len, sizeof(namebuf) - len, "%s", pdir->d_name);

--- a/src/resmom/mom_job_func.c
+++ b/src/resmom/mom_job_func.c
@@ -316,7 +316,7 @@ int remtree(
       {
       if (pdir->d_name[0] == '.' && (pdir->d_name[1] == '\0' ||
          (pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')))
-      continue;
+        continue;
 
       snprintf(namebuf + len, sizeof(namebuf) - len, "%s", pdir->d_name);
 

--- a/src/resmom/mom_job_func.c
+++ b/src/resmom/mom_job_func.c
@@ -314,8 +314,8 @@ int remtree(
 
     while ((pdir = readdir(dir)) != NULL)
       {
-      if (pdir->d_name[0] == '.' && pdir->d_name[1] == '\0' ||
-	  pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')
+        if (pdir->d_name[0] == '.' && (pdir->d_name[1] == '\0' ||
+           (pdir->d_name[1] == '.' && pdir->d_name[2] == '\0')))
         continue;
 
       snprintf(namebuf + len, sizeof(namebuf) - len, "%s", pdir->d_name);


### PR DESCRIPTION
The remtree() function recursively deletes files and directories, and skips over `.` and `..`. However, the code that matches `..` also matches file and directory names starting with `..` since there is no check for a terminating `\0`. The modified expression is also simplified by eliminating all the unnecessary parentheses; logic expressions evaluate left-to-right.
