### PR TITLE
start the thread pool in the mom after creating it

### DIFF
--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8431,6 +8431,7 @@ int setup_program_environment(void)
     }  /* END if (ptr != NULL) */
 
   initialize_threadpool(&request_pool,MOM_THREADS,MOM_THREADS,THREAD_INFINITE);
+  start_request_pool();
 
   requested_cluster_addrs = 0;
 


### PR DESCRIPTION
The mom contains all the code to create a thread pool, and a configuration setting 
`$thread_unlink_calls true`
will queue the `delete_job_files` call in the pool. However, the pool was never started and the function never ran.

