### PR TITLE
Fix for segfaults with newest nvidia drivers

### DIFF
--- a/src/resmom/nvidia.c
+++ b/src/resmom/nvidia.c
@@ -1403,7 +1403,7 @@ void generate_server_gpustatus_smi(
 
   //dkoes - with the latest drivers we are closer to 12000 bytes per a GPU
   //use a dynamic string to future-proof against even more verbose drivers
-  dynamic_string *gpu_string = get_dynamic_string(MAX_GPUS * 12000,"");
+  dynamic_string *gpu_string = get_dynamic_string(MAX_GPUS * 12000,NULL);
   dataptr = gpus(gpu_string);
 
   if (dataptr == NULL)

--- a/src/resmom/nvidia.c
+++ b/src/resmom/nvidia.c
@@ -547,7 +547,7 @@ static char *gpus(dynamic_string *result)
       {
         total_bytes_read += bytes_read;
         buf[bytes_read] = 0; //make sure null terminated
-        copy_to_end_of_dynamic_string(result, buf);
+        append_dynamic_string(result, buf);      
       }
     } while (bytes_read > 0);
 

--- a/src/resmom/nvidia.c
+++ b/src/resmom/nvidia.c
@@ -1413,7 +1413,7 @@ void generate_server_gpustatus_smi(
     }
 
   /* move past the php code*/
-  if ((dataptr = strstr(gpu_string, "<timestamp>")) != NULL)
+  if ((dataptr = strstr(dataptr, "<timestamp>")) != NULL)
     {
     MXMLFromString(&EP, dataptr, &Tail, Emsg, sizeof(Emsg));
     copy_to_end_of_dynamic_string(gpu_status, "timestamp=");
@@ -1426,7 +1426,7 @@ void generate_server_gpustatus_smi(
     return;
     }
 
-  if ((dataptr = strstr(gpu_string, "<driver_version>")) != NULL)
+  if ((dataptr = strstr(dataptr, "<driver_version>")) != NULL)
     {
     MXMLFromString(&EP, dataptr, &Tail, Emsg, sizeof(Emsg));
     copy_to_end_of_dynamic_string(gpu_status, "driver_ver=");

--- a/src/scheduler.cc/samples/fifo/constant.h
+++ b/src/scheduler.cc/samples/fifo/constant.h
@@ -117,6 +117,7 @@
 #define JOB_STARVING (RET_BASE + 16)
 #define SERVER_TOKEN_UTILIZATION (RET_BASE + 17)
 #define QUEUE_IGNORED (RET_BASE + 18)
+#define QUEUE_NEEDNODES (RET_BASE + 19)
 
 /* for SORT_BY */
 enum sort_type

--- a/src/scheduler.cc/samples/fifo/data_types.h
+++ b/src/scheduler.cc/samples/fifo/data_types.h
@@ -202,6 +202,7 @@ unsigned dedtime_queue:
   int priority;   /* priority of queue */
 
   struct resource *qres; /* list of resources on the queue */
+  char *need; /* neednodes value */
   job_info **jobs;  /* array of jobs that reside in queue */
   job_info **running_jobs; /* array of jobs in the running state */
   };

--- a/src/scheduler.cc/samples/fifo/fifo.c
+++ b/src/scheduler.cc/samples/fifo/fifo.c
@@ -506,6 +506,8 @@ int scheduling_cycle(
       jinfo->name,
       "Considering job to run");
 
+    update_job_neednodes(sd, jinfo); /*dkoes - add any needed prop to neednodes */
+
     if ((ret = is_ok_to_run_job(sd, sinfo, jinfo->queue, jinfo)) == SUCCESS)
       {
       run_update_job(sd, sinfo, jinfo->queue, jinfo);

--- a/src/scheduler.cc/samples/fifo/job_info.h
+++ b/src/scheduler.cc/samples/fifo/job_info.h
@@ -151,6 +151,11 @@ void update_job_on_run(int pbs_sd, job_info *jinfo);
 int update_job_comment(int pbs_sd, job_info *jinfo, const char *comment);
 
 /*
+ *      update_job_neednodes - update a jobs neednodes attribute based on queue
+ */
+int update_job_neednodes(int pbs_sd, job_info *jinfo);
+
+/*
  *      update_jobs_cant_run - update an array of jobs which can not run
  */
 void update_jobs_cant_run(int pbs_sd, job_info **jinfo_arr, job_info *start,

--- a/src/scheduler.cc/samples/fifo/queue_info.c
+++ b/src/scheduler.cc/samples/fifo/queue_info.c
@@ -336,7 +336,14 @@ queue_info *query_queue_info(struct batch_status *queue, server_info *sinfo)
       if (resp != NULL)
         resp -> assigned = count;
       }
-
+    else if (!strcmp(attrp -> name, ATTR_rescdflt)) /* resources_default */
+     {
+         /* dkoes - implement resources_default.neednodes = <queue_name> for
+          assigning nodes to queues */
+        if(!strcmp(attrp -> resource, "neednodes")) {
+          qinfo->need = string_dup(attrp->value);
+        }
+     }
     attrp = attrp -> next;
     }
 
@@ -381,6 +388,8 @@ queue_info *new_queue_info()
   qinfo -> name   = NULL;
 
   qinfo -> qres   = NULL;
+
+  qinfo -> need = NULL; 
 
   qinfo -> jobs   = NULL;
 
@@ -517,6 +526,9 @@ void free_queue_info(queue_info *qinfo)
 
   if (qinfo -> qres != NULL)
     free_resource_list(qinfo -> qres);
+
+  if (qinfo -> need != NULL)
+    free(qinfo -> need);
 
   if (qinfo -> running_jobs != NULL)
     free(qinfo -> running_jobs);

--- a/src/scheduler.cc/samples/fifo/sort.c
+++ b/src/scheduler.cc/samples/fifo/sort.c
@@ -103,9 +103,11 @@
  */
 int cmp_queue_prio_dsc(const void *q1, const void *q2)
   {
-  if ((*(queue_info **) q1) -> priority < (*(queue_info **) q2) -> priority)
+  queue_info *Q1 = *(queue_info **) q1;
+  queue_info *Q2 = *(queue_info **) q2;
+  if (Q1->priority < Q2->priority)
     return 1;
-  else if ((*(queue_info **) q1) -> priority > (*(queue_info **) q2) -> priority)
+  else if (Q1->priority > Q2->priority)
     return -1;
   else
     return 0;
@@ -123,7 +125,7 @@ int cmp_queue_prio_asc(const void *q1, const void *q2)
   else if ((*(queue_info **) q1) -> priority > (*(queue_info **) q2) -> priority)
     return 1;
   else
-    return -1;
+    return 0;
   }
 
 /*
@@ -281,7 +283,7 @@ int cmp_job_mem_dsc(const void *j1, const void *j2)
 /*
  *
  *      cmp_job_prio_asc - sort jobs by ascending priority
- *
+ * 
  */
 int cmp_job_prio_asc(const void *j1, const void *j2)
   {


### PR DESCRIPTION
The latest nvidia drivers (346.59) generate substantially more output when nvidia-smi is called (all the supported clock rates are now listed).  The code for parsing the results of nvidia-smi used a fixed length (96000) byte buffer and did not check for buffer overflow.  This results in segmentation faults on systems with many GPUs running the latest drivers (which are required for TitanX cards).

The fix is to read in the nvidia-smi output into a dynamic string.  This has been minimally tested.