### PR TITLE
replaced deprecated calls to interp->result

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2216,7 +2216,6 @@ tcl_init(void)
   if (Tcl_Init(interp) == TCL_ERROR)
     {
     fprintf(stderr, "Tcl_Init error: %s",
-            /* interp->result); */
 	    Tcl_GetStringResult(interp));
     }
 
@@ -2230,7 +2229,6 @@ tcl_init(void)
     {
 #endif
     fprintf(stderr, "Tclx_Init error: %s",
-            /* interp->result); */
 	    Tcl_GetStringResult(interp));
     }
 
@@ -2347,11 +2345,10 @@ void tcl_run(
     trace = (char *)Tcl_GetVar(interp, "errorInfo", 0);
 
     if (trace == NULL)
-      /* interp->result); */
       Tcl_GetStringResult(interp);
 
     fprintf(stderr, "%s: TCL error @ line %d: %s\n",
-            script, Tcl_GetErrorLine(interp)); /* interp->errorLine, trace); */
+            script, Tcl_GetErrorLine(interp)); 
     }
 
   Tcl_DeleteInterp(interp);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2216,7 +2216,8 @@ tcl_init(void)
   if (Tcl_Init(interp) == TCL_ERROR)
     {
     fprintf(stderr, "Tcl_Init error: %s",
-            interp->result);
+            /* interp->result); */
+	    Tcl_GetStringResult(interp));
     }
 
 #if TCLX
@@ -2229,7 +2230,8 @@ tcl_init(void)
     {
 #endif
     fprintf(stderr, "Tclx_Init error: %s",
-            interp->result);
+            /* interp->result); */
+	    Tcl_GetStringResult(interp));
     }
 
 #endif /* TCLX */
@@ -2345,10 +2347,11 @@ void tcl_run(
     trace = (char *)Tcl_GetVar(interp, "errorInfo", 0);
 
     if (trace == NULL)
-      trace = interp->result;
+      /* interp->result); */
+      Tcl_GetStringResult(interp);
 
     fprintf(stderr, "%s: TCL error @ line %d: %s\n",
-            script, interp->errorLine, trace);
+            script, Tcl_GetErrorLine(interp)); /* interp->errorLine, trace); */
     }
 
   Tcl_DeleteInterp(interp);

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2345,10 +2345,10 @@ void tcl_run(
     trace = (char *)Tcl_GetVar(interp, "errorInfo", 0);
 
     if (trace == NULL)
-      Tcl_GetStringResult(interp);
+      trace = Tcl_GetStringResult(interp);
 
     fprintf(stderr, "%s: TCL error @ line %d: %s\n",
-            script, Tcl_GetErrorLine(interp)); 
+            script, Tcl_GetErrorLine(interp), trace); 
     }
 
   Tcl_DeleteInterp(interp);

--- a/src/scheduler.tcl/pbs_tclWrap.c
+++ b/src/scheduler.tcl/pbs_tclWrap.c
@@ -935,7 +935,7 @@ int PBS_ReRun(
 
   if (argc != 2)
     {
-    sprintf(interp->result,
+      sprintf((char *)Tcl_GetStringResult(interp),
             "%s: wrong # args: job_id", argv[0]);
     return TCL_ERROR;
     }
@@ -946,15 +946,18 @@ int PBS_ReRun(
     SET_PBSERR(PBSE_NOSERVER);
     return TCL_OK;
     }
+  sprintf(log_buffer, "0");
+  Tcl_SetResult(interp, log_buffer, TCL_VOLATILE);
 
-  interp->result = strdup("0");
+  /* interp->result = strdup("0"); */
 
   if (pbs_rerunjob_err(connector, strdup(argv[1]), extend, &local_errno))
     {
-    interp->result = strdup("-1");
-    msg = pbs_geterrmsg(connector);
-    sprintf(log_buffer, "%s (%d)", msg ? msg : fail, local_errno);
-    log_err(-1, argv[0], log_buffer);
+      sprintf(log_buffer, "-1");
+      Tcl_SetResult(interp, log_buffer, TCL_VOLATILE);
+      msg = pbs_geterrmsg(connector);
+      sprintf(log_buffer, "%s (%d)", msg ? msg : fail, local_errno);
+      log_err(-1, argv[0], log_buffer);
     }
   else
     {

--- a/src/scheduler.tcl/pbs_tclWrap.c
+++ b/src/scheduler.tcl/pbs_tclWrap.c
@@ -935,7 +935,7 @@ int PBS_ReRun(
 
   if (argc != 2)
     {
-      sprintf((char *)Tcl_GetStringResult(interp),
+    sprintf((char *)Tcl_GetStringResult(interp),
             "%s: wrong # args: job_id", argv[0]);
     return TCL_ERROR;
     }
@@ -946,18 +946,17 @@ int PBS_ReRun(
     SET_PBSERR(PBSE_NOSERVER);
     return TCL_OK;
     }
+  
   sprintf(log_buffer, "0");
   Tcl_SetResult(interp, log_buffer, TCL_VOLATILE);
 
-  /* interp->result = strdup("0"); */
-
   if (pbs_rerunjob_err(connector, strdup(argv[1]), extend, &local_errno))
     {
-      sprintf(log_buffer, "-1");
-      Tcl_SetResult(interp, log_buffer, TCL_VOLATILE);
-      msg = pbs_geterrmsg(connector);
-      sprintf(log_buffer, "%s (%d)", msg ? msg : fail, local_errno);
-      log_err(-1, argv[0], log_buffer);
+    sprintf(log_buffer, "-1");
+    Tcl_SetResult(interp, log_buffer, TCL_VOLATILE);
+    msg = pbs_geterrmsg(connector);
+    sprintf(log_buffer, "%s (%d)", msg ? msg : fail, local_errno);
+    log_err(-1, argv[0], log_buffer);
     }
   else
     {


### PR DESCRIPTION
I found this to be necessary because I couldn't compile torque on ubuntu 14.04 because of these deprecated calls to the interp->results guy in tcl. 