### PR TITLE
If no arguments are given, qstat should still do something :)

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -3354,7 +3354,7 @@ int main(
     have_args = true;
     }
 
-  for (;optind < argc;optind++)
+  for (;optind <= argc;optind++)
     {
     located = FALSE;
 


### PR DESCRIPTION
There are two loops
- one where it is checked if `optind >= argc`
- one where it was checked if `optind < argc`

The latter case caused qstat to not produce any output, even though there are queued jobs.

This PR changes that behaviour again and will also execute the loop in case there are no arguments.
