### PR TITLE
Fixed bug in high availability setup

### DIFF
--- a/contrib/init.d/pbs_server.in
+++ b/contrib/init.d/pbs_server.in
@@ -52,12 +52,8 @@ stop() {
         exit 0
     fi
     echo -n "Shutting down TORQUE Server: "
-    $BIN_PATH/qterm
+    killproc pbs_server -TERM
     RET=$?
-    if [[ $RET -ne 0 ]]; then
-      killproc pbs_server -TERM
-      RET=$?
-    fi
 
     rm -f /var/lock/subsys/pbs_server
     echo


### PR DESCRIPTION
Fixed an incompatibility in the init script with high availability setup.

qterm would cause the active (listening) server to shutdown, which could be a remote server instead of the local server as expected.

Reverting the code to pre-4.1.3 behavior: Sending SIGTERM to local pbs_server instance, this would orderly shut down server process, regardless of HA / single master configuration.