### PR TITLE
Avoid killing running jobs due to time drift when the mom restarts 

### DIFF
--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -40,7 +40,7 @@ using namespace std;
 
 bool    do_not_display_complete = false;
 
-static void states(  
+static void states(
 
   char *string, /* I */
   char *queued,      /* O */
@@ -190,7 +190,7 @@ bool istrue(
 
 int time_to_string(
 
-  char *time_string, 
+  char *time_string,
   int   time_to_convert)
 
   {
@@ -219,7 +219,7 @@ int time_to_string(
   }
 
 int timestring_to_int(
-    
+
   const char *timestring,
   int        *req_walltime)
 
@@ -242,8 +242,8 @@ int timestring_to_int(
     free(ptr_string);
     return (PBSE_BAD_PARAMETER);
     }
-  
-  *ptr = 0; 
+
+  *ptr = 0;
   ptr++;
   hours = atoi(number);
   hours = hours * 3600;
@@ -256,14 +256,14 @@ int timestring_to_int(
     return (PBSE_BAD_PARAMETER);
     }
 
-  *ptr = 0; 
+  *ptr = 0;
   ptr++;
   minutes = atoi(number);
   minutes = minutes * 60;
   number = ptr;
 
   seconds = atoi(number);
-  
+
   *req_walltime = hours + minutes + seconds;
 
   free(ptr_string);
@@ -922,7 +922,7 @@ static void altdsp_statjob(
           snprintf(rqmem, sizeof(rqmem), "%s", cnv_size(pat->value, alt_opt));
           }
         else if (!strcmp(pat->resource, "dmem"))
-          { 
+          {
           snprintf(rqmem, sizeof(rqmem), "%s", cnv_size(pat->value, alt_opt));
           }
         else if (!strcmp(pat->resource, "vmem"))
@@ -1003,7 +1003,7 @@ static void altdsp_statjob(
       }
 
     if ((*jstate != 'Q') && (*jstate != 'C') && (*jstate != 'H'))
-      { 
+      {
       elap_time = req_walltime - rem_walltime;
       time_to_string(elap_time_string, elap_time);
       }
@@ -2237,8 +2237,8 @@ tcl_init(void)
   }
 
 void tcl_addarg(
-    
-  const char *name, 
+
+  const char *name,
   const char *arg)
 
   {
@@ -2361,16 +2361,16 @@ void tcl_run(
 #else
 #define tcl_init()
 #define tcl_addarg(name, arg)
-#define tcl_stat(type, bs, f_opt) ; 
+#define tcl_stat(type, bs, f_opt) ;
 #define tcl_run(f_opt)
 #endif /* TCL_QSTAT */
 
 
 int process_commandline_opts(
 
-  int argc, 
-  char **argv, 
-  int *exec_only_flg, 
+  int argc,
+  char **argv,
+  int *exec_only_flg,
   int *errflg_out)
 
   {
@@ -2498,9 +2498,9 @@ int process_commandline_opts(
         break;
 
       case 't':
-      
+
         t_opt = 1;
-        
+
         break;
 
       case 'u':
@@ -2775,8 +2775,8 @@ int process_commandline_opts(
 
 
 int run_job_mode(
-    
-    bool have_args, 
+
+    bool have_args,
     const char *operand,
     int  *located,
     char *server_out,
@@ -2968,7 +2968,7 @@ int run_job_mode(
           errmsg = get_err_msg(any_failed,"job", connect, job_id_out);
           break;
           }
-        
+
         if (any_failed && (retry_count < MAX_RETRIES))
           {
           pbs_disconnect(connect);
@@ -2976,7 +2976,7 @@ int run_job_mode(
           }
 
         tcl_stat("job", NULL, f_opt);
-        
+
         }
       }
     else
@@ -2985,13 +2985,13 @@ int run_job_mode(
 #ifdef TCL_QSTAT
       condition = tcl_stat("job", p_status, f_opt);
 #endif
-      
+
       if (alt_opt != 0)
         {
         altdsp_statjob(p_status, p_server, alt_opt);
         }
       else if ((f_opt == 0) ||
-               (condition)) 
+               (condition))
         {
         display_statjob(p_status, print_header, f_opt, user);
         }
@@ -3011,7 +3011,7 @@ int run_job_mode(
 
 int run_queue_mode(
 
-    bool have_args, 
+    bool have_args,
     const char *operand,
     char *server_out,
     char *queue_name_out,
@@ -3024,7 +3024,7 @@ int run_queue_mode(
   int    server_out_size = MAXSERVERNAME;
   int    retry_count = 0;
   char   destination[PBS_MAXDEST + 1];
- 
+
   struct batch_status *p_status;
 
   if (have_args == true)
@@ -3213,7 +3213,7 @@ int run_server_mode(
     break;
     } /* end while */
 
-  return(any_failed); 
+  return(any_failed);
   }
 
 
@@ -3299,7 +3299,7 @@ int main(
     print_usage();
     exit(2);
     }
-    
+
 
   if (errflg)
     {
@@ -3342,19 +3342,19 @@ int main(
     /* If no arguments, then set defaults */
     snprintf(server_out, sizeof(server_out), "@%s", def_server);
     tcl_addarg(ops, server_out);
-    
+
     job_id_out[0] = '\0';
     server_out[0] = '\0';
-    
+
     queue_name_out = NULL;
-    have_args = false;   
+    have_args = false;
     }    /* END if (optind >= argc) */
   else
     {
     have_args = true;
     }
 
-  for (;optind < argc;optind++)
+  for (;optind <= argc;optind++)
     {
     located = FALSE;
 

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -121,11 +121,11 @@
 #endif
 
 #ifndef LOG_ERR
-#define LOG_ERR 4 
+#define LOG_ERR 4
 #endif
 
 #ifndef LOG_ERR
-#define LOG_ERR 5 
+#define LOG_ERR 5
 #endif
 
 #ifndef LOG_WARNING
@@ -214,6 +214,7 @@ int chk_file_sec( const char *path, int isdir, int sticky, int disallow, int ful
 #define PBS_EVENTCLASS_ACCT 6 /* Accounting info */
 #define PBS_EVENTCLASS_NODE 7 /* Nodes           */
 #define PBS_EVENTCLASS_TRQAUTHD 8 /* trqauthd */
+#define PBS_EVENTCLASS_MOM 9 /* moms */
 
 /* definition's for pbs_log.c's log_remove_old() function */
 #define MAX_PATH_LEN    1024  /* maximum possible length of any path */

--- a/src/lib/Liblog/pbs_log.c
+++ b/src/lib/Liblog/pbs_log.c
@@ -150,7 +150,7 @@ static int      syslogopen = 0;
 #ifdef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
 pthread_mutex_t log_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 #elif defined(PTHREAD_MUTEX_RECURSIVE)
-pthread_mutex_t log_mutex = 
+pthread_mutex_t log_mutex =
   {{0, 0, 0, PTHREAD_MUTEX_RECURSIVE, _MUTEX_MAGIC}, {{{0}}}, 0};
 #endif
 
@@ -177,7 +177,8 @@ static const char *class_names[] =
   "Fil",
   "Act",
   "node",
-  "trqauthd"
+  "trqauthd",
+  "mom"
   };
 
 /* External functions called */
@@ -401,12 +402,12 @@ int log_open(
     snprintf(buf2, sizeof(buf2), "Log opened at %s", log_host_port);
   else
     snprintf(buf2, sizeof(buf2), "Log opened");
-  
+
   if (log_host_port[0])
     snprintf(buf2, sizeof(buf2), "Log opened at %s", log_host_port);
   else
     snprintf(buf2, sizeof(buf2), "Log opened");
-  
+
   log_record(
     PBSEVENT_SYSTEM,
     PBS_EVENTCLASS_SERVER,
@@ -589,7 +590,7 @@ void log_ext(
       EPtr = EBuf;
       }
 
-    sprintf(tmpLine,"%s (%d) in ", 
+    sprintf(tmpLine,"%s (%d) in ",
             EPtr,
             errnum);
     }
@@ -619,7 +620,7 @@ void log_ext(
             msg_daemonname,
             buf);
     }
-    
+
   if (log_opened > 0)
     {
     pthread_mutex_unlock(&log_mutex);
@@ -669,7 +670,7 @@ const char *log_get_severity_string(
     case LOG_EMERG:
       result = "LOG_EMERGENCY";
       break;
-    
+
     case LOG_ALERT:
       result = "LOG_ALERT";
       break;
@@ -814,11 +815,11 @@ void log_record(
   now = time((time_t *)0); /* get time for message */
 
   ptm = localtime_r(&now,&tmpPtm);
-  
+
   /* mytime used to calculate milliseconds */
-  
+
   gettimeofday(&mytime, NULL);
-  
+
   int milliseconds = mytime.tv_usec/1000;
 
   /* Do we need to switch the log? */
@@ -835,8 +836,8 @@ void log_record(
       return;
       }
     }
-  
-  time_formatted_str[0] = 0;    
+
+  time_formatted_str[0] = 0;
   log_get_set_eventclass(&eventclass, GETV);
   if (eventclass == PBS_EVENTCLASS_TRQAUTHD)
     {
@@ -924,7 +925,7 @@ void log_record(
     clearerr(logfile);
     savlog = logfile;
     logfile = fopen("/dev/console", "w");
-    /* we need to add this check to make sure the disk isn't full so we don't segfault 
+    /* we need to add this check to make sure the disk isn't full so we don't segfault
      * if we can't open this then we're going to have a nice surprise failure */
     if (logfile != NULL)
       {
@@ -936,7 +937,7 @@ void log_record(
 
     logfile = savlog;
     }
-  
+
   pthread_mutex_unlock(&log_mutex);
 
   return;
@@ -965,7 +966,7 @@ void log_close(
         snprintf(buf, sizeof(buf), "Log closed at %s", log_host_port);
       else
         snprintf(buf, sizeof(buf), "Log closed");
-       
+
       pthread_mutex_unlock(&log_mutex);
       log_record(
         PBSEVENT_SYSTEM,
@@ -1049,16 +1050,16 @@ int log_remove_old(
 
   {
   char tmpPath[MAX_PATH_LEN];
- 
+
   DIR *DirHandle;
   struct dirent *FileHandle;
   struct stat sbuf;
   unsigned long FMTime;
   unsigned long TTime;
   char  log_buf[LOCAL_LOG_BUF_SIZE];
- 
+
   int IsDir = FALSE;
- 
+
   /* check the input for an empty path */
   if ((DirPath == NULL) || (DirPath[0] == '\0'))
     {
@@ -1071,19 +1072,19 @@ int log_remove_old(
     }
 
   /* open directory for reading */
-      
+
   DirHandle = opendir(DirPath);
 
-  /* fail if path couldn't be opened */  
+  /* fail if path couldn't be opened */
   if (DirHandle == (DIR *)NULL)
     {
     return(-1);
     }
 
   FileHandle = readdir(DirHandle);
-  
+
   while (FileHandle != (struct dirent *)NULL)
-    {    
+    {
     /* attempt to delete old files */
 
     if (!strcmp(FileHandle->d_name,".") ||
@@ -1100,7 +1101,7 @@ int log_remove_old(
       DirPath,
       FileHandle->d_name);
 
-    if (stat(tmpPath,&sbuf) == -1) 
+    if (stat(tmpPath,&sbuf) == -1)
       {
       /* -1 is the failure value for stat */
 
@@ -1114,7 +1115,7 @@ int log_remove_old(
     TTime = time((time_t *)NULL);
     /* set FMTime's value */
     FMTime = (unsigned long)sbuf.st_mtime;
-    
+
     if ((IsDir == FALSE) &&
         (FMTime + ExpireTime) < TTime)
       {
@@ -1147,7 +1148,7 @@ void log_roll(
   int err = 0;
   char *source  = NULL;
   char *dest    = NULL;
-  
+
   pthread_mutex_lock(&log_mutex);
 
   if (!log_opened)
@@ -1269,7 +1270,7 @@ void job_log_roll(
   int err = 0;
   char *source  = NULL;
   char *dest    = NULL;
-      
+
   pthread_mutex_lock(&job_log_mutex);
 
   if (!job_log_opened)
@@ -1377,7 +1378,7 @@ done_job_roll:
       "Job Log",
       "Job Log Rolled");
     }
-    
+
   pthread_mutex_unlock(&job_log_mutex);
 
   return;
@@ -1400,7 +1401,7 @@ long log_size(void)
 
   struct stat file_stat;
 #endif
-  
+
   pthread_mutex_lock(&log_mutex);
 
 #if defined(HAVE_STRUCT_STAT64) && defined(HAVE_STAT64) && defined(LARGEFILE_WORKS)
@@ -1418,7 +1419,7 @@ long log_size(void)
 
     return(0);
     }
-  
+
   if (!log_opened) {
       pthread_mutex_unlock(&log_mutex);
       log_err(EAGAIN, "log_size", "PBS cannot find size of log file because logfile has not been opened");
@@ -1442,7 +1443,7 @@ long job_log_size(void)
 
   struct stat file_stat;
 #endif
- 
+
   memset(&file_stat, 0, sizeof(file_stat));
   pthread_mutex_lock(&job_log_mutex);
 
@@ -1460,7 +1461,7 @@ long job_log_size(void)
 
     return(0);
     }
-  
+
   pthread_mutex_unlock(&job_log_mutex);
 
   return(file_stat.st_size / 1024);
@@ -1468,7 +1469,7 @@ long job_log_size(void)
 
 
 void print_trace(
-    
+
   int socknum)
 
   {
@@ -1484,7 +1485,7 @@ void print_trace(
   meth_names = backtrace_symbols(array, size);
   snprintf(meth_name, sizeof(meth_name), "pt - pos %d", socknum);
   snprintf(msg, sizeof(msg), "Obtained %d stack frames.\n", size);
-  log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, meth_name, msg); 
+  log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, meth_name, msg);
   for (cntr = 0; cntr < size; cntr++)
     {
     log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, meth_name, meth_names[cntr]);
@@ -1496,7 +1497,7 @@ void print_trace(
 
 void log_get_set_eventclass(
 
-  int *objclass, 
+  int *objclass,
   SGetter action)
 
   {
@@ -1511,7 +1512,7 @@ void log_get_set_eventclass(
 
 void log_format_trq_timestamp(
 
-  char *time_formatted_str, 
+  char *time_formatted_str,
   unsigned int buflen)
 
   {
@@ -1521,7 +1522,7 @@ void log_format_trq_timestamp(
   struct tm      result;
   unsigned int   milisec=0;
 
-  gettimeofday(&tv, NULL); 
+  gettimeofday(&tv, NULL);
   curtime=tv.tv_sec;
 
   localtime_r(&curtime, &result);
@@ -1537,22 +1538,22 @@ void log_set_hostname_sharelogging(const char *server_name, const char *server_p
   char *hostname = NULL;
   struct hostent *he;
   struct in_addr **addr_list;
-         
+
   if (server_name)
      hostname = (char *)server_name;
   else if (gethostname(hostnm, sizeof(hostnm)) == 0)
      hostname = hostnm;
 
-  if (hostname) 
+  if (hostname)
     {
-    if ((he = gethostbyname(hostname)) == NULL) 
+    if ((he = gethostbyname(hostname)) == NULL)
       {
       strcpy(ip, "null");
       }
     else
       {
       addr_list = (struct in_addr **) he->h_addr_list;
-      if (addr_list[0]) 
+      if (addr_list[0])
         snprintf(ip , sizeof(ip), "%s", inet_ntoa(*addr_list[0]));
       else
         strcpy(ip, "null");
@@ -1565,7 +1566,7 @@ void log_set_hostname_sharelogging(const char *server_name, const char *server_p
     hostname = hostnm;
     }
 
-  snprintf(log_host_port, sizeof(log_host_port), "%s:%s (host: %s)", 
+  snprintf(log_host_port, sizeof(log_host_port), "%s:%s (host: %s)",
     ip, server_port, hostname);
   }
 

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -4654,16 +4654,17 @@ void scan_non_child_tasks(void)
         if((job_start_time != 0)&&
             (session_start_time != 0))
           {
-          if(abs(job_start_time - session_start_time) < 5)
+          if(abs(job_start_time - session_start_time) < 3600)
             {
             found = 1;
+            if(job_start_time != session_start_time)
+              {
+              log_drift_event = 1;
+              }
             }
           else
             {
-              if(LOGLEVEL >= 7)
-                {
-                log_drift_event = 1;
-                }
+            log_drift_event = 1;
             }
           }
         else
@@ -4707,7 +4708,7 @@ void scan_non_child_tasks(void)
               proc_stat_t *ts = get_proc_stat(ps->session);
               if(ts == NULL)
                 continue;
-              if(ts->start_time == (unsigned long)pJob->ji_wattr[JOB_ATR_system_start_time].at_val.at_long)
+              if(abs(ts->start_time - (unsigned long)pJob->ji_wattr[JOB_ATR_system_start_time].at_val.at_long) < 3600)
                 {
                 found = 1;
                 break;
@@ -4730,8 +4731,6 @@ void scan_non_child_tasks(void)
         char buf[MAXLINE];
 
         extern int exiting_tasks;
-
-        log_drift_event = 1;
 
         sprintf(buf, "found exited session %d for task %d in job %s",
             pTask->ti_qs.ti_sid,
@@ -4763,7 +4762,7 @@ void scan_non_child_tasks(void)
         exiting_tasks = 1;
         }
       }
-      if(log_drift_event)
+      if(log_drift_event || LOGLEVEL >= 7)
       {
           sprintf(log_buffer, "DRIFT debug: comparing linux_time %ld; job_start_time %ld and session_start_time[%ld] %ld: difference %d",
           linux_time,

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -253,10 +253,8 @@ void proc_get_btime(void)
 
   fclose(fp);
 
-  if(LOGLEVEL >= 7) {
-      sprintf(log_buffer, "DRIFT debug: getting btime, setting linux_time to %ld", linux_time);
-      log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-  }
+  sprintf(log_buffer, "DRIFT debug: getting btime, setting linux_time to %ld", linux_time);
+  log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_MOM, "linux_time", log_buffer);
 
   return;
   }  /* END proc_get_btime() */
@@ -4578,6 +4576,7 @@ void scan_non_child_tasks(void)
   {
   job *pJob;
   static int first_time = TRUE;
+  int log_drift_event = 0;
 
   DIR *pdir;  /* use local pdir to prevent race conditions associated w/global pdir (VPAC) */
 
@@ -4655,19 +4654,16 @@ void scan_non_child_tasks(void)
         if((job_start_time != 0)&&
             (session_start_time != 0))
           {
-              if(LOGLEVEL >= 7)
-              {
-              sprintf(log_buffer, "Comparing linux_time %ld; job_start_time %ld and session_start_time[%ld] %ld: difference %d",
-                  linux_time,
-                  job_start_time,
-                  job_session_id,
-                  session_start_time,
-                  abs(job_start_time - session_start_time));
-              log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pJob->ji_qs.ji_jobid, log_buffer);
-              }
           if(abs(job_start_time - session_start_time) < 5)
             {
             found = 1;
+            }
+          else
+            {
+              if(LOGLEVEL >= 7)
+                {
+                log_drift_event = 1;
+                }
             }
           }
         else
@@ -4735,6 +4731,8 @@ void scan_non_child_tasks(void)
 
         extern int exiting_tasks;
 
+        log_drift_event = 1;
+
         sprintf(buf, "found exited session %d for task %d in job %s",
             pTask->ti_qs.ti_sid,
             pTask->ti_qs.ti_task,
@@ -4764,6 +4762,16 @@ void scan_non_child_tasks(void)
 
         exiting_tasks = 1;
         }
+      }
+      if(log_drift_event)
+      {
+          sprintf(log_buffer, "DRIFT debug: comparing linux_time %ld; job_start_time %ld and session_start_time[%ld] %ld: difference %d",
+          linux_time,
+          job_start_time,
+          job_session_id,
+          session_start_time,
+          abs(job_start_time - session_start_time));
+          log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pJob->ji_qs.ji_jobid, log_buffer);
       }
     }    /* END for (job = GET_NEXT(svr_alljobs)) */
 

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -131,7 +131,7 @@ extern struct  rm_attribute    *momgetattr(char *);
 extern long     system_ncpus;
 #ifdef NUMA_SUPPORT
 extern int       num_node_boards;
-extern nodeboard node_boards[]; 
+extern nodeboard node_boards[];
 extern int       numa_index;
 #else
 extern char  path_meminfo[MAX_LINE];
@@ -253,6 +253,11 @@ void proc_get_btime(void)
 
   fclose(fp);
 
+  if(LOGLEVEL >= 7) {
+      sprintf(log_buffer, "DRIFT debug: getting btime, setting linux_time to %ld", linux_time);
+      log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
+  }
+
   return;
   }  /* END proc_get_btime() */
 
@@ -287,7 +292,7 @@ void skip_space_delimited_values(
 
     if (curr_ptr == NULL)
       break;
-    
+
     spaces_found++;
     curr_ptr++;
     }
@@ -317,7 +322,7 @@ void skip_space_delimited_values(
  * <flags> <minflt>* <cminflt>* <majflt>* <cmajflt> <utime> <stime>
  * <cutime> <cstime> <priority>* <nice>* <0>* <itrealvalue>* <starttime>
  * <vsize> <rss> ...
- * and populates the relevant values into ps. Values marked with * are 
+ * and populates the relevant values into ps. Values marked with * are
  * ignored.
  *
  * @param buffer - the buffer containing this information. I
@@ -339,7 +344,7 @@ int populate_stats_from_the_buffer(
   char          *curr_ptr;
   char          *ptr;
   unsigned long  jstarttime;
-  
+
   static int Hertz  = 0;
   static int Hertz_errored = 0;
 
@@ -380,7 +385,7 @@ int populate_stats_from_the_buffer(
   snprintf(path, path_size, "%s", ptr + 1);
 
   curr_ptr = lastbracket;
-  
+
   // last bracket is currently in the format
   //  '%c %d %d %d %*d %*d %u %*u %*u %*u %*u %lu %lu %lu' +
   //  ' %lu %*ld %*ld %*u %*ld %lu %llu %lld'
@@ -388,7 +393,7 @@ int populate_stats_from_the_buffer(
   // skip the ' ' and read the state
   curr_ptr++;
   ps.state = *curr_ptr;
-  
+
   // move past this value and the next space
   curr_ptr += 2;
 
@@ -417,7 +422,7 @@ int populate_stats_from_the_buffer(
   // read the utime - cycles that the process has been in user mode
   ps.utime = strtoll(curr_ptr, &curr_ptr, 10);
   curr_ptr++;
-  
+
   // read the stime - cycles that the process has been in system mode
   ps.stime = strtoll(curr_ptr, &curr_ptr, 10);
   curr_ptr++;
@@ -443,7 +448,7 @@ int populate_stats_from_the_buffer(
 
   // read the stack size
   ps.rss = strtoll(curr_ptr, &curr_ptr, 10);
-  
+
   ps.start_time = linux_time + JTOS(jstarttime);
   ps.name = path;
 
@@ -552,7 +557,7 @@ long long get_memacct_resi(pid_t pid)
 
 /*
  * get_proc_mem_from_path()
- * @returns a pointer to a struct containing the memory information 
+ * @returns a pointer to a struct containing the memory information
  * @pre-cond: path must point to a valid path of a meminfo system file
  */
 
@@ -774,7 +779,7 @@ proc_mem_t *get_proc_mem(void)
     }
 #else
   mem = get_proc_mem_from_path(path_meminfo);
-  
+
   if(mem == NULL)
     return (NULL);
 
@@ -833,7 +838,7 @@ proc_mem_t *get_proc_mem(void)
 #endif /* PNOT */
 
 /*
- * sets oom_adj score for current process 
+ * sets oom_adj score for current process
  * requires root privileges or CAP_SYS_RESOURCE to succeed
  */
 
@@ -876,7 +881,7 @@ void dep_initialize(void)
   if ((pdir = opendir(procfs)) == NULL)
     {
     log_err(errno, __func__, "opendir");
-    
+
     return;
     }
 
@@ -885,7 +890,7 @@ void dep_initialize(void)
   /* LKF: make pbs_mom processes immune to oom killer's killing frenzy if requested*/
   if (mom_oom_immunize != 0)
     {
-    
+
     if (oom_adj(-17) < 0)
       {
       log_record(
@@ -1573,7 +1578,7 @@ int mom_set_limits(
     {
     retval = oom_adj(job_oom_score_adjust);
 
-    if ( LOGLEVEL >= 2 ) 
+    if ( LOGLEVEL >= 2 )
       {
       sprintf(log_buffer, "setting oom_adj '%s'",
         (retval != -1) ? "succeeded" : "failed");
@@ -1911,7 +1916,7 @@ int mom_set_limits(
              (!strcmp(pname, "mpplabel")))
       {
       /* NO-OP */
-      }   
+      }
     else if ((pres->rs_defin->rs_flags & ATR_DFLAG_RMOMIG) == 0)
       {
       /* don't recognize and not marked as ignore by mom */
@@ -2212,7 +2217,7 @@ int mom_get_sample(void)
     if ((pdir = opendir(procfs)) == NULL)
       return(PBSE_SYSTEM);
     }
-    
+
   rewinddir(pdir);
 
   while ((dent = readdir(pdir)) != NULL)
@@ -2283,7 +2288,7 @@ int mom_get_sample(void)
     log_record(PBSEVENT_DEBUG, 0, __func__, log_buffer);
     }
 
-  /* We have filled the proc_array table. Now find all of the processes that actually belong to a job and 
+  /* We have filled the proc_array table. Now find all of the processes that actually belong to a job and
      add them to the pid2jobsid_map associating the process id with the session id of the job to which it belongs */
 
   for ( int i = 0; i < nproc; i++)
@@ -2326,7 +2331,7 @@ int mom_get_sample(void)
 /*
  * Measure job resource usage and compare with its limits.
  *
- * If it has exceeded any well-formed polled limit return the limit that 
+ * If it has exceeded any well-formed polled limit return the limit that
  * it exceeded.
  * Otherwise, return PBSE_NONE.  log_buffer is populated with failure.
  */
@@ -2800,7 +2805,7 @@ int kill_task(
   do
     {
     ctThisIteration = 0;
-    
+
     /* NOTE:  do not use cached proc-buffer since we need up-to-date info */
 #ifdef PENABLE_LINUX26_CPUSETS
 
@@ -2808,7 +2813,7 @@ int kill_task(
      * collect stats of processes running in and below the Torque cpuset, only
      * This relies on reliable process starters for MPI, which bind their tasks
      * to the cpuset of the job. */
- 
+
 #ifdef USELIBCPUSET
     pids = get_cpuset_pidlist(TTORQUECPUSET_BASE, pids);
 #else
@@ -2847,13 +2852,13 @@ int kill_task(
 
         continue;
         }
-      
+
       if ((sesid == ps->session) ||
           (ProcIsChild(procfs,pid,ptask->ti_qs.ti_parentjobid) == TRUE))
-        
+
         {
         NumProcessesFound++;
-        
+
         if ((ps->state == 'Z') ||
             (ps->pid == 0))
           {
@@ -2862,16 +2867,16 @@ int kill_task(
            * which to kill(2) means 'every process in the process
            * group of the current process'.
            */
-          
+
           sprintf(log_buffer, "%s: not killing process (pid=%d/state=%c) with sig %d",
             __func__, ps->pid, ps->state, sig);
-          
+
           log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, ptask->ti_qs.ti_parentjobid, log_buffer);
           }  /* END if ((ps->state == 'Z') || (ps->pid == 0)) */
         else
           {
           int i = 0;
-          
+
           if (ps->pid == mompid)
             {
             /*
@@ -2881,30 +2886,30 @@ int kill_task(
              * session id.  We check this to make sure MOM doesn't kill
              * herself.
              */
-    
+
             if (LOGLEVEL >= 3)
               {
               sprintf(log_buffer, "%s: not killing process %d. Avoid sending signal because child task still has MOM's session id", __func__, ps->pid);
-              
+
               log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, ptask->ti_qs.ti_parentjobid, log_buffer);
               }
-            
+
             if ((sig == SIGKILL) ||
                 (sig == SIGTERM))
               {
               ++ctThisIteration; //Ultimately this is  task that will need to be killed.
               }
-            
+
             continue;
             }  /* END if (ps->pid == mompid) */
-          
+
           if (sig == SIGKILL)
             {
             sprintf(log_buffer, "%s: killing pid %d task %d gracefully with sig %d",
               __func__, ps->pid, ptask->ti_qs.ti_task, SIGTERM);
-            
+
             log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, ptask->ti_qs.ti_parentjobid, log_buffer);
-            
+
             if (pg == 0)
               {
               /* make sure we only send a SIGTERM one time */
@@ -2922,7 +2927,7 @@ int kill_task(
                 ptask->ti_qs.ti_status = TI_STATE_SIGTERM;
                 }
               }
-            
+
             for (i = 0;i < 20;i++)
               {
               /* check if process is gone */
@@ -2934,29 +2939,29 @@ int kill_task(
                 {
                 sprintf(log_buffer, "%s: process (pid=%d/state=%c) after sig %d",
                   __func__, ps->pid, ps->state, SIGTERM);
-      
+
                 log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, ptask->ti_qs.ti_parentjobid, log_buffer);
-      
+
                 if (ps->state == 'Z')
                   break;
                 }
-              
+
               /* try to kill again */
               if (kill(ps->pid, 0) == -1)
                 break;
-              
+
               }  /* END for (i = 0) */
             }    /* END if (sig == SIGKILL) */
           else
             {
             i = 20;
             }
-          
+
           if (i >= 20)
             {
             /* NOTE: handle race-condition where process goes zombie as a result
              * of previous SIGTERM */
-            
+
             /* update proc info from /proc/<PID>/stat */
             if ((ps = get_proc_stat(ps->pid)) != NULL)
               {
@@ -2967,22 +2972,22 @@ int kill_task(
                  * which to kill(2) means 'every process in the process
                  * group of the current process'.
                  */
-      
+
                 sprintf(log_buffer, "%s: not killing process (pid=%d/state=%c) with sig %d",
                   __func__, ps->pid, ps->state, sig);
-                
+
                 log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB,	ptask->ti_qs.ti_parentjobid, log_buffer);
                 }  /* END if ((ps->state == 'Z') || (ps->pid == 0)) */
               else
                 {
                 /* kill process hard */
-                
+
                 /* why is this not killing with SIGKILL? */
                 sprintf(log_buffer, "%s: killing pid %d task %d with sig %d",
                   __func__, ps->pid, ptask->ti_qs.ti_task, sig);
-                
+
                 log_record(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, ptask->ti_qs.ti_parentjobid, log_buffer);
-                
+
                 if (pg == 0)
                   {
                   if (sig != SIGTERM)
@@ -3011,7 +3016,7 @@ int kill_task(
                 }
               }    /* END if ((ps = get_proc_stat(ps->pid)) != NULL) */
             }      /* END if (i >= 20) */
-          
+
           ++ct;
           }  /* END else ((ps->state == 'Z') || (ps->pid == 0)) */
         }    /* END if (sesid == ps->session) */
@@ -3051,7 +3056,7 @@ int kill_task(
 
     task_save(ptask);
 
-    sprintf(log_buffer, 
+    sprintf(log_buffer,
       "%s: job %s adopted task %d was marked as terminated because task's PID was no longer found, sid=%d",
       __func__,
       ptask->ti_qs.ti_parentjobid,
@@ -3490,7 +3495,7 @@ static char *resi_job(
 
   {
   int                 i;
-  int                 found = 0; 
+  int                 found = 0;
   unsigned long long  resisize;
   proc_stat_t        *ps;
 #ifdef USELIBMEMACCT
@@ -3581,9 +3586,9 @@ static char *resi_proc(
     }
 
 #ifdef USELIBMEMACCT
-  
+
   /* Ask memacctd for weighted rss of pid, use this instead of ps->rss */
- 
+
   if ((w_rss = get_memacct_resi(ps->pid)) == -1)
     sprintf(ret_string, "%llukb", (ps->rss * (unsigned long long)pagesize) >> 10);
   else
@@ -4263,7 +4268,7 @@ const char *ncpus(
  */
 
 int find_file(
-    
+
   const char *path,
   const char *filename)
 
@@ -4289,7 +4294,7 @@ int find_file(
     buf = token;
     buf += "/";
     buf += filename;
-        
+
     rc = stat(buf.c_str(), &statBuf);
     if (rc == 0)
       {
@@ -4297,7 +4302,7 @@ int find_file(
       return(TRUE);
       }
     }
-      
+
   free(malloc_str);
 
   return(FALSE);
@@ -4650,7 +4655,17 @@ void scan_non_child_tasks(void)
         if((job_start_time != 0)&&
             (session_start_time != 0))
           {
-          if(job_start_time == session_start_time)
+              if(LOGLEVEL >= 7)
+              {
+              sprintf(log_buffer, "Comparing linux_time %ld; job_start_time %ld and session_start_time[%ld] %ld: difference %d",
+                  linux_time,
+                  job_start_time,
+                  job_session_id,
+                  session_start_time,
+                  abs(job_start_time - session_start_time));
+              log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pJob->ji_qs.ji_jobid, log_buffer);
+              }
+          if(abs(job_start_time - session_start_time) < 5)
             {
             found = 1;
             }
@@ -4676,7 +4691,7 @@ void scan_non_child_tasks(void)
           if ((pdir = opendir(procfs)) == NULL)
             return;
           }
-          
+
         rewinddir(pdir);
 
         while ((dent = readdir(pdir)) != NULL)
@@ -5004,7 +5019,7 @@ int get_la(
  * The activity of a cpu is calculated from the content of /proc/stat like done
  * by top and related tools.
  */
- 
+
 void collect_cpuact(void)
   {
   FILE  *fp;
@@ -5041,7 +5056,7 @@ void collect_cpuact(void)
 
     sprintf(log_buffer, "system contains %ld CPUs", system_ncpus);
     log_record(PBSEVENT_SYSTEM, 0, __func__, log_buffer);
-  
+
     if (system_ncpus)
       {
       if ((cpu_array = (proc_cpu_t *)calloc(system_ncpus, sizeof(proc_cpu_t))) == NULL)
@@ -5063,10 +5078,10 @@ void collect_cpuact(void)
       if (fscanf(fp, "%s", label) != 1)
         /* Format error */
         break;
-                  
+
       if (sscanf(label, "cpu%d", &cpu_id) != 1)
         /* Line does not report cpu activities */
-        continue; 
+        continue;
 
       if (cpu_id >= system_ncpus)
         /* Ups, more cpus than found in /proc/cpuinfo */
@@ -5075,7 +5090,7 @@ void collect_cpuact(void)
       if (fscanf(fp, " %llu %llu %llu %llu %llu", &usr, &nice, &sys, &idle, &wait) != 5)
         /* Format error */
         break;
- 
+
       cpu_array[cpu_id].idle_total = idle;
       cpu_array[cpu_id].busy_total = usr + nice + sys + wait;
 
@@ -5086,7 +5101,7 @@ void collect_cpuact(void)
   /* Calculate cpu activity for each nodeboard */
   for (i = 0; i < num_node_boards; i++)
     {
-    
+
     /* Sum up cpu counters of relevant CPUs */
     totidle = totbusy = 0;
     hwloc_bitmap_foreach_begin(cpu_id, node_boards[i].cpuset)
@@ -5095,7 +5110,7 @@ void collect_cpuact(void)
       totbusy += cpu_array[cpu_id].busy_total;
       }
     hwloc_bitmap_foreach_end();
-    
+
     /* If there are counters from a previous call, evaluate */
     if ((prevtot = node_boards[i].pstat_idle + node_boards[i].pstat_busy) != 0)
       {
@@ -5124,7 +5139,7 @@ void collect_cpuact(void)
 const char *cpuact(
 
   struct rm_attribute *attrib)
-  
+
   {
   if (attrib != NULL)
     {
@@ -5575,5 +5590,3 @@ mbool_t ProcIsChild(
   }  /* END ProcIsChild() */
 
 /* END mom_mach.c */
-
-

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -236,7 +236,7 @@ struct var_table      vtable;  /* for building up job's environ */
 
 #ifdef NUMA_SUPPORT
 extern int            num_node_boards;
-extern nodeboard      node_boards[MAX_NODE_BOARDS]; 
+extern nodeboard      node_boards[MAX_NODE_BOARDS];
 extern int            numa_index;
 #endif
 
@@ -418,14 +418,14 @@ void no_hang(
 
   {
   log_event(PBSEVENT_JOB, PBS_EVENTCLASS_REQUEST, " ", "alarm timed-out connect to qsub");
-  
+
   return;
   }   /* END no_hang() */
 
 
 
 struct passwd *check_pwd(
-    
+
   job *pjob) /* I (modified) */
 
   {
@@ -660,8 +660,8 @@ void exec_bail(
 
 
 
-/* 
- * becomes the user for pjob 
+/*
+ * becomes the user for pjob
  *
  * @param pjob - the job whose user we should become
  * @return PBSE_BADUSER on failure
@@ -708,7 +708,7 @@ int become_the_user(
 
 
 int become_the_user_sjr(
-    
+
   job                 *pjob,
   int                  write,
   int                  read,
@@ -720,11 +720,11 @@ int become_the_user_sjr(
     if (write_ac_socket(2, log_buffer, strlen(log_buffer)) == -1)
       {
       }
-    
+
     fsync(2);
-    
+
     log_err(errno, __func__, log_buffer);
-    
+
     starter_return(write, read, JOB_EXEC_FAIL2, sjr);
     }
 
@@ -788,14 +788,14 @@ int open_demux(
         sprintf(log_buffer, "%s: local port: %d", __func__, local_port);
         log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, __func__, log_buffer);
         }
-      
+
       return(sock);
       }
-    
+
     sprintf(log_buffer, "connect failed: addr: %ld   port: %d",  addr, port);
-    
+
     log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, __func__, log_buffer);
-    
+
     switch (errno)
       {
 
@@ -818,9 +818,9 @@ int open_demux(
       case ECONNREFUSED:
 
         sprintf(log_buffer, "%s: cannot connect to %s", __func__, netaddr(&remote));
-        
+
         log_err(errno, __func__, log_buffer);
-        
+
         sleep(2);
 
         continue;
@@ -842,11 +842,11 @@ int open_demux(
   sprintf(log_buffer, "%s: connect %s",
     __func__,
     netaddr(&remote));
-  
+
   log_err(errno, __func__, log_buffer);
-  
+
   close(sock);
-  
+
   return(-1);
   }   /* END open_demux() */
 
@@ -895,23 +895,23 @@ static int open_pty(
       }
 
 #ifdef SETCONTROLLINGTTY
-    
+
 #if defined(_CRAY)
     ioctl(0, TCCLRCTTY, 0);
-    
+
     ioctl(pts, TCSETCTTY, 0);  /* make controlling */
-    
+
 #elif defined(TCSETCTTY)
     ioctl(pts, TCSETCTTY, 0);  /* make controlling */
-    
+
 #elif defined(TIOCSCTTY)
     ioctl(pts, TIOCSCTTY, 0);
-    
+
 #endif
-    
+
 #endif /* SETCONTROLLINGTTY */
     }
-  
+
   return(pts);
   }   /* END open_pty() */
 
@@ -1162,7 +1162,7 @@ int mkdirtree(
 /* If our config allows it, construct tmpdir path */
 
 int TTmpDirName(
-    
+
   job  *pjob,   /* I */
   char *tmpdir, /* O */
   int   tmpdir_size)
@@ -1312,7 +1312,7 @@ int TMakeTmpDir(
 /*
  * get_indices_from_exec_str
  *
- * parses an exec style string and places the absolute indices in a 
+ * parses an exec style string and places the absolute indices in a
  * list in buf
  *
  * the exec_mics string in NUMA is in the format:
@@ -1324,7 +1324,7 @@ int TMakeTmpDir(
  *
  * @param exec_str - the string we're parsing
  * @param buf - where the list of absolute mic indices goes
- * @param buf_size - maximum size that can be written into buf 
+ * @param buf_size - maximum size that can be written into buf
  */
 
 int get_indices_from_exec_str(
@@ -1463,7 +1463,7 @@ int get_num_nodes_ppn(
   if ((tmp = strstr((char *)res_str, ppn_str)) != NULL)
     {
     tmp += strlen(ppn_str);
-        
+
     if ((n = strtol(tmp, NULL, 10)) > 0)
       {
       // overflow?
@@ -1478,15 +1478,15 @@ int get_num_nodes_ppn(
       return(1);
       }
     }
-  
+
   other_reqs = (char *)res_str;
- 
+
   // process rest of resource string counting only nodes (not ppns)
   while ((other_reqs = strchr(other_reqs, '+')) != NULL)
     {
     // skip '+'
     other_reqs++;
-  
+
     // do we have a node count?
     if ((n = strtol(other_reqs, &other_reqs, 10)) > 0)
       {
@@ -1587,9 +1587,9 @@ int InitUserEnv(
   vtable.v_block = vtable.v_block_start;
 
   vtable.v_ensize = num_var_else + num_var_env + j + EXTRA_ENV_PTRS + (vstrs != NULL ? vstrs->as_usedptr : 0);
-  
+
   vtable.v_used = 0;
-  
+
   vtable.v_envp = (char **)calloc(vtable.v_ensize, sizeof(char *));
 
   if (vtable.v_envp == NULL)
@@ -1611,7 +1611,7 @@ int InitUserEnv(
   if (LOGLEVEL >= 10)
     {
     sprintf(log_buffer, "local env added, count: %d", j);
-    
+
     log_ext(-1, __func__, log_buffer, LOG_DEBUG);
     }
 
@@ -1634,21 +1634,21 @@ int InitUserEnv(
     if (LOGLEVEL >= 10)
       {
       sprintf(log_buffer, "job env added, count: %d", j);
-      
+
       log_ext(-1, __func__, log_buffer, LOG_DEBUG);
       }
     }     /* END if (vstrs != NULL) */
-  
+
   /* HOME */
-  
+
   if (pjob->ji_grpcache != NULL)
     bld_env_variables(&vtable, variables_else[tveHome], pjob->ji_grpcache->gc_homedir);
-  
+
   /* LOGNAME */
 
   if (pwdp != NULL)
     bld_env_variables(&vtable, variables_else[tveLogName], pwdp->pw_name);
-  
+
   /* PBS_JOBNAME */
 
   bld_env_variables(&vtable,
@@ -1658,13 +1658,13 @@ int InitUserEnv(
   /* PBS_JOBID */
 
   bld_env_variables(&vtable, variables_else[tveJobID], pjob->ji_qs.ji_jobid);
-  
+
   /* PBS_QUEUE */
-  
+
   bld_env_variables(&vtable,
       variables_else[tveQueue],
       pjob->ji_wattr[JOB_ATR_in_queue].at_val.at_str);
-  
+
   /* SHELL */
 
   if (shell != NULL)
@@ -1680,9 +1680,9 @@ int InitUserEnv(
   bld_env_variables(&vtable,
       variables_else[tveJobCookie],
       pjob->ji_wattr[JOB_ATR_Cookie].at_val.at_str);
-  
+
   /* PBS_NODENUM */
-  
+
   sprintf(buf, "%d", pjob->ji_nodeid);
 
   bld_env_variables(&vtable, variables_else[tveNodeNum], buf);
@@ -1761,7 +1761,7 @@ int InitUserEnv(
   if (presc != NULL)
     {
     sprintf(buf, "%ld", presc->rs_value.at_val.at_long);
-    
+
     bld_env_variables(&vtable, variables_else[tveNumNodes], buf);
     }
 
@@ -1780,18 +1780,18 @@ int InitUserEnv(
 
   if (LOGLEVEL >= 3)
     {
-    snprintf(log_buffer, sizeof(log_buffer), 
+    snprintf(log_buffer, sizeof(log_buffer),
       "Added %s=%s to environment",
       variables_else[tveNumNodesStr], buf);
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
     }
-   
+
   sprintf(buf,"%d",num_ppn);
   bld_env_variables(&vtable,variables_else[tveNumPpn],buf);
 
   if (LOGLEVEL >= 3)
     {
-    snprintf(log_buffer, sizeof(log_buffer), 
+    snprintf(log_buffer, sizeof(log_buffer),
       "Added %s=%s to environment",
       variables_else[tveNumPpn], buf);
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
@@ -1799,18 +1799,18 @@ int InitUserEnv(
 
   /* setup TMPDIR */
 
-  if ((!usertmpdir) && 
+  if ((!usertmpdir) &&
       (TTmpDirName(pjob, buf, sizeof(buf))))
     bld_env_variables(&vtable, variables_else[tveTmpDir], buf);
 
   /* PBS_VERSION */
 
   sprintf(buf, "TORQUE-%s", PACKAGE_VERSION);
-  
+
   bld_env_variables(&vtable, variables_else[tveVerID], buf);
-  
+
   /* passed-in environment for tasks */
-  
+
   if (envp != NULL)
     {
     for (j = 0;envp[j];j++)
@@ -1840,7 +1840,7 @@ int mom_jobstarter_execute_job(
 
   {
   /* Launch job executable with cr_run command so that cr_checkpoint command will work. */
-  
+
   /* shuffle up the existing args */
   arg[5] = arg[4];
   arg[4] = arg[3];
@@ -1851,7 +1851,7 @@ int mom_jobstarter_execute_job(
      executable is launched, so we don't have to worry about freeing
      this calloc later */
   arg[1] = (char *)calloc(1, strlen(shell) + 1);
-  
+
   if (arg[1] == NULL)
     {
     log_err(errno,__func__, "cannot alloc env");
@@ -1866,13 +1866,13 @@ int mom_jobstarter_execute_job(
     {
     std::string cmd;
     create_command(cmd, arg);
-    
+
     sprintf(log_buffer, "execing jobstarter command (%s)\n", cmd.c_str());
     log_ext(-1, __func__, log_buffer, LOG_DEBUG);
     }
-  
+
   execve(jobstarter_exe_name, arg, vtable->v_envp);
-  
+
   return(PBSE_NONE);
   } /* END mom_jobstarter_execute_job() */
 
@@ -1886,10 +1886,10 @@ int mom_jobstarter_execute_job(
  */
 int open_tcp_stream_to_sisters(
 
-  job               *pjob, 
+  job               *pjob,
   int                com,
   tm_event_t         parent_event,
-  int                mom_radix, 
+  int                mom_radix,
   hnodent           *hosts, /* This is really an array of hnodent */
   struct radix_buf **sister_list,
   tlist_head        *phead,
@@ -1903,49 +1903,49 @@ int open_tcp_stream_to_sisters(
   eventent        *ep;
   svrattrl        *psatl;
   struct tcp_chan *chan = NULL;
-  
+
   np = hosts;
   pjob->ji_outstanding = 0;
-  
+
   /* the sister lists have been made. Now contact the intermediate moms as designated by mom_radix */
   for (i = 1; i <= mom_radix; i++)
     {
     np++;
-    
+
     log_buffer[0] = '\0';
-    
+
     if (sister_list[i-1]->count < 2)
       {
       continue;
       }
-    
+
     pjob->ji_outstanding++;
-    
+
     stream = tcp_connect_sockaddr((struct sockaddr *)&np->sock_addr,sizeof(np->sock_addr));
-    
+
     if (IS_VALID_STREAM(stream) == FALSE)
       {
       pjob->ji_nodekill = i;
-      
+
       if (log_buffer[0] != '\0')
         {
         sprintf(log_buffer, "tcp_connect_sockaddr failed on %s - job id %s", np->hn_host, pjob->ji_qs.ji_jobid);
         }
-      
+
       log_err(errno, __func__, log_buffer);
       log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, __func__, log_buffer);
-      
+
       exec_bail(pjob, JOB_EXEC_FAIL1);
-      
+
       return(PBSE_SISCOMM);
       }
-    
+
     ep = event_alloc(com, np, TM_NULL_EVENT, TM_NULL_TASK);
     ep->ee_parent_event = parent_event;
 
     sprintf(log_buffer, "event %d to host %s: com: %d", ep->ee_event, np->hn_host,com);
     log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_JOB, __func__, log_buffer);
-    
+
     if ((chan = DIS_tcp_setup(stream)) == NULL)
       {
       close(stream);
@@ -2014,7 +2014,7 @@ int open_tcp_stream_to_sisters(
     close(stream);
 
     }
-  
+
   return(PBSE_NONE);
   } /* end open_tcp_stream_to_sisters */
 
@@ -2062,7 +2062,7 @@ struct radix_buf **allocate_sister_list(
   {
   struct radix_buf **sister_list;
   int                i;
-  
+
   /* create sister lists to send out to intermediate moms */
   if ((sister_list = (struct radix_buf **)calloc((size_t)radix, sizeof(struct radix_buf *))) == NULL)
     {
@@ -2123,46 +2123,46 @@ int TMomFinalizeJob1(
   {
   int                 i;
   int                 rc;
-  
+
   pbs_attribute      *pattr;
   pbs_attribute      *pattri;
 #ifndef MOM_FORCENODEFILE
   resource_def       *prd;
   resource           *presc;
 #endif
-  
+
 #ifndef NUMA_SUPPORT
   torque_socklen_t   slen;
   struct sockaddr_in  saddr;
 #endif /* ndef NUMA_SUPPORT */
-  
+
   char                buf[MAXPATHLEN + 2];
   time_t              time_now;
-  
+
   struct stat         sb;
-  
+
   *SC = 0;
   time_now = time(0);
-  
+
   if (TJE == NULL)
     {
     sprintf(log_buffer, "bad param in %s", __func__);
-    
+
     *SC = JOB_EXEC_RETRY;
-    
+
     return(FAILURE);
     }
 
   /* initialize job exec struct */
-  
+
   memset(TJE, 0, sizeof(pjobexec_t));
-  
+
   TJE->ptc = -1;
- 
+
   strcpy(TJE->jobid, pjob->ji_qs.ji_jobid);
-  
+
   /* prepare job environment */
-  
+
 #ifndef NUMA_SUPPORT
   if (pjob->ji_numnodes > 1)
     {
@@ -2171,31 +2171,31 @@ int TMomFinalizeJob1(
     ** sockets are stored there so they can be closed later as
     ** Main MOM will not need them after the job is going.
     */
-    
+
     slen = sizeof(saddr);
-    
+
     if (getsockname(pjob->ji_stdout, (struct sockaddr *)&saddr, &slen) == -1)
       {
       sprintf(log_buffer, "getsockname on stdout");
-      
+
       *SC = JOB_EXEC_RETRY;
 
       return(FAILURE);
       }
-    
+
     TJE->port_out = (int)ntohs(saddr.sin_port);
 
     slen = sizeof(saddr);
-    
+
     if (getsockname(pjob->ji_stderr, (struct sockaddr *)&saddr, &slen) == -1)
       {
       sprintf(log_buffer, "getsockname on stderr");
-      
+
       *SC = JOB_EXEC_RETRY;
-      
+
       return(FAILURE);
       }
-    
+
     TJE->port_err = (int)ntohs(saddr.sin_port);
     }
   else
@@ -2204,73 +2204,73 @@ int TMomFinalizeJob1(
     TJE->port_out = -1;
     TJE->port_err = -1;
     }
-  
+
   /* did the job request nodes?  will need to setup node file */
 
   pattr = &pjob->ji_wattr[JOB_ATR_resource];
-  
+
 #ifdef MOM_FORCENODEFILE
   pjob->ji_flags |= MOM_HAS_NODEFILE;
-  
+
 #else /* MOM_FORCENODEFILE */
   prd = find_resc_def(svr_resc_def, "neednodes", svr_resc_size);
   presc = find_resc_entry(pattr, prd);
-  
+
   if (presc != NULL)
     pjob->ji_flags |= MOM_HAS_NODEFILE;
-  
+
 #endif /* MOM_FORCENODEFILE */
   /*
     * get the password entry for the user under which the job is to be run
     * we do this now to save a few things in the job structure
    */
-  
+
   if ((TJE->pwdp = (void *)check_pwd(pjob)) == NULL)
     {
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-    
+
     *SC = JOB_EXEC_FAIL1;
-    
+
     return(FAILURE);
     }
-  
+
 #if IBM_SP2==2        /* IBM SP with PSSP 3.1 */
-  
+
   /* load IBM SP switch table */
-  
+
   if (load_sp_switch(pjob) != 0)
     {
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-    
+
     *SC = JOB_EXEC_RETRY;
-    
+
     return(FAILURE);
     }
-  
+
 #endif /* IBM SP */
-  
+
   /* Starting job */
-  
+
   mom_checkpoint_init_job_periodic_timer(pjob);
-  
+
   if (mom_checkpoint_job_has_checkpoint(pjob))
     {
     rc = mom_checkpoint_start_restart(pjob);
-    
+
     if (rc == PBSE_NONE)
       {
       /* SUCCESS */
-      
+
       log_ext(-1, __func__, "Restart succeeded", LOG_DEBUG);
-      
+
       /* reset mtime so walltime will not include held time */
       /* update to time now minus the time already used    */
       /* unless it is suspended, see request.c/req_signal() */
-      
+
       /* check time on the file not the directory */
-      
+
       get_chkpt_dir_to_use(pjob, buf, sizeof(buf));
-      if (sizeof(buf) - strlen(buf) > 
+      if (sizeof(buf) - strlen(buf) >
             strlen(pjob->ji_wattr[JOB_ATR_checkpoint_name].at_val.at_str) + 1)
         {
         strcat(buf, "/");
@@ -2292,7 +2292,7 @@ int TMomFinalizeJob1(
           }
         pjob->ji_qs.ji_stime = time_now - (sb.st_mtime - pjob->ji_qs.ji_stime);
         pjob->ji_qs.ji_substate = JOB_SUBSTATE_RUNNING;
-        
+
         if (mom_get_sample() != PBSE_NONE)
           mom_set_use(pjob);
         }
@@ -2300,21 +2300,21 @@ int TMomFinalizeJob1(
         {
         pjob->ji_qs.ji_substate = JOB_SUBSTATE_SUSPEND;
         }
-      
+
       *SC = 0;
-      
+
       return(FAILURE);
       }
     else
       {
       /* FAILURE */
-      
+
       log_err(-1, __func__, "Restart failed");
-      
+
       /* retry for any kind of changable thing */
-      
+
       if ((errno == EAGAIN) ||
-          
+
 #ifdef  ERFLOCK
           (errno == ERFLOCK) ||
 #endif
@@ -2345,16 +2345,16 @@ int TMomFinalizeJob1(
         pjob->ji_qs.ji_un.ji_momt.ji_exitstat = JOB_EXEC_BADRESRT;
         *SC = JOB_EXEC_FAIL1;
         }
-      
+
       pjob->ji_qs.ji_substate = JOB_SUBSTATE_EXITING;
-      
+
       exiting_tasks = 1;
-      
+
       sprintf(log_buffer, "Restart failed, error %d (%s)",
         errno, pbs_strerror(errno));
 
       log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-      
+
       return(FAILURE);
       }
     }  /* end of if mom_checkpoint_job_has_checkpoint(pjob) */
@@ -2365,12 +2365,12 @@ int TMomFinalizeJob1(
    * NOTE: we overload the job field ji_jobque for this as it
    * is not used otherwise by MOM
    */
-  
+
   if ((pjob->ji_numnodes > 1) || (mom_do_poll(pjob) != 0))
     append_link(&mom_polljobs, &pjob->ji_jobque, pjob);
-  
+
   pattri = &pjob->ji_wattr[JOB_ATR_interactive];
-  
+
   if ((pattri->at_flags & ATR_VFLAG_SET) &&
       (pattri->at_val.at_long != 0))
     {
@@ -2380,84 +2380,84 @@ int TMomFinalizeJob1(
     {
     TJE->is_interactive = FALSE;
     }
-  
+
   if (TJE->is_interactive == TRUE)
     {
     /*
      * open a master pty, need to do it here before we fork,
      * to save the slave name in the master's job structure
      */
-    
+
     if ((TJE->ptc = open_master(&TJE->ptc_name)) < 0)
       {
       log_err(errno, __func__, "cannot open master pty");
-      
+
       *SC = JOB_EXEC_RETRY;
-      
+
       return(FAILURE);
       }
-    
+
     FDMOVE(TJE->ptc)
-      
+
     /* save pty name in job output/error file name */
     pattr = &pjob->ji_wattr[JOB_ATR_outpath];
-    
+
     job_attr_def[JOB_ATR_outpath].at_free(pattr);
-    
+
     job_attr_def[JOB_ATR_outpath].at_decode(
         pattr,
         NULL,
         NULL,
         TJE->ptc_name,
         0);
-    
+
     pjob->ji_wattr[JOB_ATR_outpath].at_flags =
       (ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_SEND);
-    
+
     pattr = &pjob->ji_wattr[JOB_ATR_errpath];
-    
+
     job_attr_def[JOB_ATR_errpath].at_free(pattr);
-    
+
     job_attr_def[JOB_ATR_errpath].at_decode(
         pattr,
         NULL,
         NULL,
         TJE->ptc_name,
         0);
-    
+
     pjob->ji_wattr[JOB_ATR_errpath].at_flags =
       (ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_SEND);
     }   /* END if (TJE->is_interactive == TRUE) */
-  
+
 #if SHELL_USE_ARGV == 0
   #if SHELL_INVOKE == 1
-  
+
   if (TJE->is_interactive == FALSE)
     {
     /* need a pipe on which to write the shell script   */
     /* file name to the input of the shell                      */
-    
+
     if (pipe(TJE->pipe_script) == -1)
       {
       sprintf(log_buffer,
         "Failed to create shell name pipe, errno = %d (%s)",
         errno, strerror(errno));
-      
+
       log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-      
+
       *SC = JOB_EXEC_RETRY;
-      
+
       return(FAILURE);
       }
     }     /* END if (TJE->is_interactive == FALSE) */
-  
+
 #endif /* SHELL_INVOKE */
 #endif /* !SHELL_USE_ARGV */
-  
+
   /* create pipes between MOM and the job starter   */
   /* fork the job starter which will become the job */
-  
-  if ((pipe(TJE->mjspipe) == -1) || 
+
+  if ((pipe(TJE->mjspipe) == -1) ||
       (pipe(TJE->jsmpipe) == -1))
     {
     i = -1;
@@ -2465,28 +2465,28 @@ int TMomFinalizeJob1(
   else
     {
     i = 0;
-    
+
     /* make sure pipe file descriptors are above 2 */
-    
+
     if (TJE->jsmpipe[1] < 3)
       {
       TJE->upfds = fcntl(TJE->jsmpipe[1], F_DUPFD, 3);
-      
+
       close(TJE->jsmpipe[1]);
-      
+
       TJE->jsmpipe[1] = 0;
       }
     else
       {
       TJE->upfds = TJE->jsmpipe[1];
       }
-    
+
     if (TJE->mjspipe[0] < 3)
       {
       TJE->downfds = fcntl(TJE->mjspipe[0], F_DUPFD, 3);
-      
+
       close(TJE->mjspipe[0]);
-      
+
       TJE->mjspipe[0] = 0;
       }
     else
@@ -2494,33 +2494,33 @@ int TMomFinalizeJob1(
       TJE->downfds = TJE->mjspipe[0];
       }
     }
-  
+
   if ((i == -1) || (TJE->upfds < 3) || (TJE->downfds < 3))
     {
     sprintf(log_buffer, "cannot create communication pipe");
-    
+
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-    
+
     *SC = JOB_EXEC_RETRY;
-    
+
     return(FAILURE);
     }
-  
+
   if ((TJE->ptask = (void *)pbs_task_create(pjob, TM_NULL_TASK)) == NULL)
     {
     sprintf(log_buffer, "cannot create job task");
-    
+
     log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
-    
+
     *SC = JOB_EXEC_RETRY;
-    
+
     return(FAILURE);
     }
-  
+
   pjob->ji_qs.ji_substate = JOB_SUBSTATE_STARTING;
-  
+
   pjob->ji_qs.ji_stime = time_now;
-  
+
   return(SUCCESS);
   }   /* END TMomFinalizeJob1() */
 
@@ -2546,9 +2546,9 @@ int TMomFinalizeJob2(
 #endif  /* !SHELL_USE_ARGV */
 
   job                  *pjob;
-  
+
   pjob  = mom_find_job(TJE->jobid);
-  
+
   if (LOGLEVEL >= 4)
     {
     log_record(
@@ -2557,41 +2557,41 @@ int TMomFinalizeJob2(
       pjob->ji_qs.ji_jobid,
       "about to fork child which will become job");
     }
-  
+
   /* fork the child that will become the job. */
   if ((cpid = fork_me(-1)) < 0)
     {
     /* fork failed */
-    
+
     sprintf(log_buffer, "fork kf job '%s' failed in (errno=%d, '%s')",
       pjob->ji_qs.ji_jobid,
       errno,
       strerror(errno));
-    
+
     log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, __func__, log_buffer);
-    
+
     *SC = JOB_EXEC_RETRY;
-    
+
     return(FAILURE);
     }
-  
+
   if (cpid == 0)
     {
     /* CHILD:  handle child activities */
     TMomFinalizeChild(TJE);
-    
+
     /*NOTREACHED*/
     }
-  
+
   /* parent */
-  
+
   close(TJE->upfds);
-  
+
   close(TJE->downfds);
 
   if (TJE->ptc >= 0)
     close(TJE->ptc);
- 
+
   if (multi_mom)
     {
     snprintf(buf, sizeof(buf), "%s%s%d%s",
@@ -2600,7 +2600,7 @@ int TMomFinalizeJob2(
   else
     snprintf(buf, sizeof(buf), "%s%s%s",
       path_jobs, pjob->ji_qs.ji_fileprefix, JOB_SCRIPT_SUFFIX);
-  
+
   if (chown(
         buf,
         pjob->ji_qs.ji_un.ji_momt.ji_exuid,
@@ -2616,10 +2616,10 @@ int TMomFinalizeJob2(
 
   /* put the job pid in the job structure */
   pjob->ji_job_pid_set->insert(cpid);
- 
+
 #if SHELL_USE_ARGV == 0
   #if SHELL_INVOKE == 1
-  
+
   if (TJE->is_interactive == FALSE)
     {
     int k;
@@ -2632,7 +2632,7 @@ int TMomFinalizeJob2(
         strncpy(buf, "exec ", 5);
         }
       }
-    
+
     /* pass name of shell script on pipe */
     /* will be stdin of shell  */
 
@@ -2649,40 +2649,40 @@ int TMomFinalizeJob2(
 
     if (sizeof(buf) - strlen(buf) > 1)
       strcat(buf, "\n");  /* setup above */
-    
+
     i = strlen(buf);
     j = 0;
-    
+
     while (j < i)
       {
       if ((k = write_ac_socket(TJE->pipe_script[1], buf + j, i - j)) < 0)
         {
         if (errno == EINTR)
           continue;
-        
+
         break;
         }
-      
+
       j += k;
       }
-    
+
     close(TJE->pipe_script[1]);
     }  /* END if (TJE->is_interactive == FALSE) */
-  
+
   #endif /* SHELL_INVOKE */
 #endif  /* !SHELL_USE_ARGV */
-  
+
   /* SUCCESS:  parent returns */
-  
+
   if (LOGLEVEL >= 3)
     {
     sprintf(log_buffer, "phase 2 of job launch successfully completed");
-    
+
     log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
     }
-  
+
   *SC = 0;
-  
+
   return(SUCCESS);
   }   /* END TMomFinalizeJob2() */
 
@@ -2691,7 +2691,7 @@ int TMomFinalizeJob2(
 
 
 int determine_umask(
-    
+
   int  uid)    /* I */
 
   {
@@ -2932,7 +2932,7 @@ int write_attr_to_file(
  * @return PBSE_NONE if success, error code otherwise
  */
 int write_nodes_to_file(
-    
+
   job  *pjob) /* I */
 
   {
@@ -2993,7 +2993,7 @@ int write_nodes_to_file(
         fprintf(file, "%s%s\n",
                 ptr,
                 nodefile_suffix);
-        } 
+        }
       else
         {
         fprintf(file, "%s\n",
@@ -3002,7 +3002,7 @@ int write_nodes_to_file(
 
       ptr = strtok(NULL, ":");
       }
-    } 
+    }
   else
     {
     vnodenum = pjob->ji_numvnod;
@@ -3011,8 +3011,8 @@ int write_nodes_to_file(
       {
       vnodent *vp = &pjob->ji_vnods[j];
 
-#ifdef NUMA_SUPPORT 
-      /* make sure that the nodefile has actual hostnames, not 
+#ifdef NUMA_SUPPORT
+      /* make sure that the nodefile has actual hostnames, not
        * numa names */
       char *dash = NULL;
       char *tmp = vp->vn_host->hn_host;
@@ -3041,7 +3041,7 @@ int write_nodes_to_file(
         fprintf(file, "%s%s\n",
           vp->vn_host->hn_host,
           nodefile_suffix);
-        } 
+        }
       else
         {
         fprintf(file, "%s\n", vp->vn_host->hn_host);
@@ -3087,7 +3087,7 @@ void take_care_of_nodes_file(
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
 #endif  /* NVIDIA_GPUS */
     }   /* END if (pjob->ji_flags & MOM_HAS_NODEFILE) */
-  
+
   if (LOGLEVEL >= 10)
     log_ext(-1, __func__, "node file created", LOG_DEBUG);
   } /* END take_care_of_nodes_file() */
@@ -3104,13 +3104,13 @@ void handle_cpuset_creation(
   {
 #ifdef PENABLE_LINUX26_CPUSETS
   if (use_cpusets(pjob) == TRUE)
-    {    
+    {
     if (LOGLEVEL >= 6)
       {
       sprintf(log_buffer, "about to create cpuset for job %s.\n", pjob->ji_qs.ji_jobid);
       log_ext(-1, __func__, log_buffer, LOG_DEBUG);
       }
-    
+
     if (create_job_cpuset(pjob) == FAILURE)
       {
       /* FAILURE */
@@ -3140,7 +3140,7 @@ void handle_reservation(
   resource  *pres;
   int        use_nppn = TRUE;
   int        nppcu = APBASIL_DEFAULT_NPPCU_VALUE; /* default */
-  
+
   sjr->sj_session = setsid();
 
   if (is_login_node == TRUE)
@@ -3151,7 +3151,7 @@ void handle_reservation(
 #else
     pagg = sjr->sj_session;
 #endif /* USEJOBCREATE */
-    
+
     sjr->sj_jobid = pagg;
     pjob->ji_wattr[JOB_ATR_pagg_id].at_val.at_ll = pagg;
     pjob->ji_wattr[JOB_ATR_pagg_id].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODIFY;
@@ -3159,7 +3159,7 @@ void handle_reservation(
 
  /* set up the job session (update sjr) */
   memcpy(TJE->sjr, sjr, sizeof(struct startjob_rtn));
-    
+
   if (is_login_node == TRUE)
     {
     char *exec_str;
@@ -3182,7 +3182,7 @@ void handle_reservation(
     pres = find_resc_entry(
              &pjob->ji_wattr[JOB_ATR_resource],
              find_resc_def(svr_resc_def, "mppdepth", svr_resc_size));
-    
+
     if ((pres != NULL) &&
         (pres->rs_value.at_val.at_long != 0))
       mppdepth = pres->rs_value.at_val.at_long;
@@ -3201,7 +3201,7 @@ void handle_reservation(
       {
       mppnodes = strdup(pres->rs_value.at_val.at_str);
       }
-    
+
     std::string cray_frequency = "";
     resource *presc = find_resc_entry(&pjob->ji_wattr[JOB_ATR_resource],
               find_resc_def(svr_resc_def, "cpuclock", svr_resc_size));
@@ -3224,21 +3224,21 @@ void handle_reservation(
           cray_frequency);
 
     if(mppnodes != NULL) free(mppnodes);
-    
+
     if (rsv_id != NULL)
       {
       sjr->sj_rsvid = atoi(rsv_id);
       free(rsv_id);
       }
-    
+
     if (j < 0)
       {
       snprintf(log_buffer, sizeof(log_buffer),
         "Couldn't create the reservation for job %s",
         pjob->ji_qs.ji_jobid);
-    
+
       log_err(-1, __func__, log_buffer);
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_RETRY, sjr);
       }
     }
@@ -3271,7 +3271,7 @@ void handle_prologs(
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
     }
-    
+
   if (LOGLEVEL >= 10)
     log_ext(-1, __func__, "prolog complete", LOG_DEBUG);
 
@@ -3279,7 +3279,7 @@ void handle_prologs(
   if ((rc = run_pelog(PE_PROLOGUSER, path_prologuser, pjob, PE_IO_TYPE_ASIS, FALSE)) != PBSE_NONE)
     {
     log_err(-1, __func__, "user prolog failed");
-    
+
     if ((TJE->is_interactive == FALSE) &&
         (rc != 1))
       {
@@ -3290,21 +3290,21 @@ void handle_prologs(
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
     }
-    
+
   if (LOGLEVEL >= 10)
     log_ext(-1, __func__, "user prolog complete", LOG_DEBUG);
-  
+
   presc = find_resc_entry(
       &pjob->ji_wattr[JOB_ATR_resource],
       find_resc_def(svr_resc_def, "prologue", svr_resc_size));
-  
+
   if ((presc != NULL))
     {
-    if ((presc->rs_value.at_flags & ATR_VFLAG_SET) && 
+    if ((presc->rs_value.at_flags & ATR_VFLAG_SET) &&
         (presc->rs_value.at_val.at_str != NULL))
-      {          
+      {
       path_prologuserjob = get_local_script_path(pjob, presc->rs_value.at_val.at_str);
-      
+
       if (path_prologuserjob)
         {
         if ((rc = run_pelog(PE_PROLOGUSERJOB, path_prologuserjob, pjob, PE_IO_TYPE_ASIS, FALSE)) != PBSE_NONE)
@@ -3322,9 +3322,9 @@ void handle_prologs(
             starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
             }
           }
-        
+
         free(path_prologuserjob);
-   
+
         if (LOGLEVEL >= 10)
           log_ext(-1, __func__, "job prolog complete", LOG_DEBUG);
         }
@@ -3358,7 +3358,7 @@ int start_interactive_session(
   /* We have an "interactive" job, connect the standard  */
   /* streams to a socket connected to qsub.    */
   /*************************************************************/
-  
+
   sigemptyset(&act.sa_mask);
 #ifdef SA_INTERRUPT
   act.sa_flags   = SA_INTERRUPT;
@@ -3366,38 +3366,38 @@ int start_interactive_session(
   act.sa_flags   = 0;
 #endif /* SA_INTERRUPT */
   act.sa_handler = no_hang;
-  
+
   sigaction(SIGALRM, &act, NULL);
-  
+
   /* only giving ourselves 5 seconds to connect to qsub
    * and get term settings */
-  
+
   alarm(5);
-  
+
   /* once we connect to qsub and open a pty, the user can send us
    * a ctrl-c.  It is important that we block this until we exec()
    * the user's shell or we exit and the job gets stuck */
   act.sa_handler = SIG_IGN;
-  
+
   sigaction(SIGINT, &act, (struct sigaction *)0);
-  
+
   /* Set environment to reflect interactive */
   bld_env_variables(&vtable, "PBS_ENVIRONMENT", "PBS_INTERACTIVE");
-  
+
   /* get host where qsub resides */
   phost = arst_string("PBS_O_HOST", &pjob->ji_wattr[JOB_ATR_variables]);
   pport = pjob->ji_wattr[JOB_ATR_interactive].at_val.at_long;
-  
+
   if ((phost == NULL) ||
       ((phost = strchr(phost, '=')) == NULL))
     {
     log_err(-1, __func__, "PBS_O_HOST not set");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   phost++;
-  
+
   if (submithost_suffix != NULL)
     {
     snprintf(qsubhostname, qsubhostname_size, "%s%s",
@@ -3416,47 +3416,47 @@ int start_interactive_session(
       qsubhostname,
       pport,
       EMsg);
-    
+
     log_err(errno, __func__, log_buffer);
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   FDMOVE(*qsub_sock_ptr);
-  
+
   /* send jobid as validation to qsub */
   if ((*qsub_sock_ptr < 0)||
       (write_ac_socket(*qsub_sock_ptr, pjob->ji_qs.ji_jobid, PBS_MAXSVRJOBID + 1) != PBS_MAXSVRJOBID + 1))
     {
     log_err(errno, __func__, "cannot write jobid");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   /* receive terminal type and window size */
   if ((termtype = rcvttype(*qsub_sock_ptr)) == NULL)
     {
     log_err(errno, __func__, "cannot get termtype");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   bld_env_variables(&vtable, termtype, NULL);
   *(vtable.v_envp + vtable.v_used) = NULL; /* null term */
-  
+
   if (rcvwinsize(*qsub_sock_ptr) == -1)
     {
     log_err(errno, __func__, "cannot get winsize");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   /* turn off alarm set around qsub connect activities */
   alarm(0);
-  
+
   act.sa_handler = SIG_DFL;
   act.sa_flags   = 0;
-  
+
   sigaction(SIGALRM, &act, NULL);
 
 
@@ -3464,7 +3464,7 @@ int start_interactive_session(
   if ((*pts_ptr = open_pty(pjob)) < 0)
     {
     log_err(errno, __func__, "cannot open slave");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
 
@@ -3489,14 +3489,14 @@ void start_interactive_reader(
   close(TJE->downfds);
   close(1);
   close(2);
-  
+
   sigemptyset(&act->sa_mask);
-  
+
   act->sa_flags   = SA_NOCLDSTOP;
   act->sa_handler = catchinter;
-  
+
   sigaction(SIGCHLD, act, NULL);
-  
+
   mom_reader_go = 1;
   mom_reader(qsub_sock, TJE->ptc);
   } /* END start_interactive_reader() */
@@ -3520,28 +3520,28 @@ void setup_interactive_job(
   int                    shellpid;
 
   handle_reservation(pjob, sjr, TJE);
-  
+
   start_interactive_session(pjob, sjr, TJE, pts_ptr, qsub_sock_ptr, qsubhostname, qsubhostname_size);
 
   memset(&act, 0, sizeof(act));
   sigemptyset(&act.sa_mask);
   act.sa_handler = SIG_IGN;  /* setup to ignore SIGTERM */
-  
+
   writerpid = fork();
 
   if (writerpid == 0)
     {
     /* child is "writer" process */
     sigaction(SIGTERM, &act, NULL);
-    
+
     close(TJE->upfds);
     close(TJE->downfds);
     close(*pts_ptr);
-    
+
     mom_writer(*qsub_sock_ptr, TJE->ptc);
-    
+
     shutdown(*qsub_sock_ptr, 2);
-    
+
     exit(0);
     }
   else if (writerpid > 0)
@@ -3551,19 +3551,19 @@ void setup_interactive_job(
     ** again.  the child becomes the job while the
     ** parent becomes the reader.
     */
-    
+
     close(1);
     close(2);
     dup2(*pts_ptr, 1);
     dup2(*pts_ptr, 2);
-    
+
     fflush(stdout);
     fflush(stderr);
-    
+
     set_termcc(*pts_ptr); /* set terminal control char */
-    
+
     setwinsize(*pts_ptr); /* set window size to qsub's */
-    
+
     /* run prolog - interactive job */
     handle_prologs(pjob, sjr, TJE);
 
@@ -3571,26 +3571,26 @@ void setup_interactive_job(
     /* Add a workload management start record */
     add_wkm_start(sjr->sj_jobid, pjob->ji_qs.ji_jobid);
 #endif /* ENABLE_CSA */
-    
+
     shellpid = fork();
-    
+
     if (shellpid == 0)
       {
       /*********************************************/
       /* child - this will be the interactive job  */
       /* i/o is to slave tty        */
       /*********************************************/
-      
+
       close(0);
-      
+
       dup2(*pts_ptr, 0);
-      
+
       fflush(stdin);
-      
+
       close(TJE->ptc);  /* close master side */
       close(*pts_ptr);  /* dup'ed above */
       close(*qsub_sock_ptr);
-      
+
       /* continue setting up and exec-ing shell */
       }
     else
@@ -3604,21 +3604,21 @@ void setup_interactive_job(
         {
         log_err(errno, __func__, "can't fork reader");
         }
-      
+
       /* make sure qsub gets EOF */
       shutdown(*qsub_sock_ptr, 2);
-      
+
       /* change pty back to available after job is done */
       if (chmod(TJE->ptc_name, 0666) != 0)
         {
           log_err(errno, __func__, "can't chmod 0666 to change pty back to available");
         }
-      
+
       if (chown(TJE->ptc_name, 0, 0) == -1)
         {
           log_err(errno, __func__, "can't chown pty");
         }
-      
+
       exit(0);
       }
     }     /* END if (writerpid > 0) */
@@ -3626,18 +3626,18 @@ void setup_interactive_job(
     {
     /* FAILURE - fork failed */
     log_err(errno, __func__, "cannot fork nanny");
-    
+
     /* change pty back to available */
     if (chmod(TJE->ptc_name, 0666) != 0)
       {
         log_err(errno, __func__, "can't chmod 0666 to change pty back to available");
       }
-    
+
     if (chown(TJE->ptc_name, 0, 0) == -1)
       {
         log_err(errno, __func__, "can't chown ptc");
       }
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_RETRY, sjr);
     }
   } /* END setup_interactive_job() */
@@ -3657,57 +3657,57 @@ void set_job_script_as_stdin(
   char  buf[MAXPATHLEN + 2];
 #endif
 
-  
+
 #if SHELL_USE_ARGV == 1
   /* connect stdin to /dev/null and feed the name of
    * the script on the command line */
- 
+
   script_in = open("/dev/null", O_RDONLY, 0);
 
 #elif SHELL_INVOKE == 1
-  /* if passing script file name as input to shell */  
+  /* if passing script file name as input to shell */
   close(TJE->pipe_script[1]);
-  
+
   script_in = TJE->pipe_script[0];
-  
+
 #else /* SHELL_USE_ARGV || SHELL_INVOKE */
   /* if passing script itself as input to shell */
-  
+
   strcpy(buf, path_jobs);
   strcat(buf, pjob->ji_qs.ji_fileprefix);
-  
+
   if (multi_mom)
     {
     sprintf(portname,"%d",pbs_rm_port);
     strcat(buf,portname);
     }
-  
+
   strcat(buf, JOB_SCRIPT_SUFFIX);
-  
+
   if ((script_in = open(buf, O_RDONLY, 0)) < 0)
     {
     if (errno == ENOENT)
       script_in = open("/dev/null", O_RDONLY, 0);
     }
-  
+
 #endif  /* SHELL_USE_ARGV */
-  
+
   if (LOGLEVEL >= 10)
     log_ext(-1, __func__, "opening script", LOG_DEBUG);
-  
+
   if (script_in < 0)
     {
     log_err(errno, __func__, "unable to open script");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL1, sjr);
     }
-  
+
   FDMOVE(script_in); /* make sure descriptor > 2 */
-  
+
   if (script_in > 0)
     {
     close(0);
-    
+
     if (dup(script_in) > 0)
       {
       close(script_in);
@@ -3731,30 +3731,30 @@ void setup_batch_job(
   /* We have a "normal" batch job, connect the standard  */
   /* streams to files      */
   /*************************************************************/
-  
+
   /* set Environment to reflect batch */
-  
+
   bld_env_variables(&vtable, "PBS_ENVIRONMENT", "PBS_BATCH");
   bld_env_variables(&vtable, "ENVIRONMENT", "BATCH");
 
   set_job_script_as_stdin(pjob, sjr, TJE);
-  
+
   /* NOTE:  set arg2 to 5 to enable file open timeout check */
   if (open_std_out_err(pjob, 0) == -1)
     {
     log_err(-1, __func__, "unable to open stdout/stderr descriptors");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_STDOUTFAIL, sjr);
     }
-  
+
   if (LOGLEVEL >= 10)
     log_ext(-1, __func__, "stdout/stderr opened", LOG_DEBUG);
-  
+
   handle_reservation(pjob, sjr, TJE);
-  
+
   /* run prolog - standard batch job */
   handle_prologs(pjob, sjr, TJE);
-  
+
 #ifdef ENABLE_CSA
   /* Add a workload management start record */
   add_wkm_start(sjr->sj_jobid, pjob->ji_qs.ji_jobid);
@@ -3838,15 +3838,15 @@ void go_to_init_dir(
     sprintf(log_buffer, "PBS: chdir to '%.256s' failed: %s\n",
       idir,
       strerror(errno));
-    
+
     if (write_ac_socket(2, log_buffer, strlen(log_buffer)) == -1)
       {
       }
-    
+
     fsync(2);
-    
+
     log_err(errno, __func__, log_buffer);
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
     }
 
@@ -3903,7 +3903,7 @@ void restore_SIGINT()
 
   {
   struct sigaction act;
-  
+
   /* restore SIGINT so that the child shell can use ctrl-c */
   sigemptyset(&act.sa_mask);
   act.sa_flags   = 0;
@@ -3928,7 +3928,7 @@ void restore_SIGINT()
  */
 
 void setup_interactive_command_if_present(
-    
+
   job                  *pjob,
   struct startjob_rtn  *sjr,
   pjobexec_t           *TJE,
@@ -3941,35 +3941,35 @@ void setup_interactive_command_if_present(
   if ((pjob->ji_wattr[JOB_ATR_inter_cmd].at_flags & ATR_VFLAG_SET) != 0)
     {
     arg[aindex] = (char *)calloc(1, strlen("-c") + 1);
-    
+
     if (arg[aindex] == NULL)
       {
       log_err(errno, __func__, "cannot alloc env");
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
-    
+
     strcpy(arg[aindex], "-c");
-    
+
     arg[aindex + 1] = NULL;
-    
+
     aindex++;
-    
+
     arg[aindex] = (char *)calloc(1, strlen(pjob->ji_wattr[JOB_ATR_inter_cmd].at_val.at_str) + 1);
-    
+
     if (arg[aindex] == NULL)
       {
       log_err(errno, __func__, "cannot alloc env");
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
-    
+
     log_ext(-1, __func__, log_buffer, LOG_DEBUG);
-    
+
     strcpy(arg[aindex], pjob->ji_wattr[JOB_ATR_inter_cmd].at_val.at_str);
-    
+
     arg[aindex + 1] = NULL;
-    
+
     aindex++;
     }
 
@@ -3979,7 +3979,7 @@ void setup_interactive_command_if_present(
 
 
 void launch_the_job_normally(
-    
+
   char  *shell,
   char **arg,
   char **job_env)
@@ -3988,13 +3988,13 @@ void launch_the_job_normally(
   if (LOGLEVEL >= 10)
     {
     std::string cmd;
-   
+
     create_command(cmd, arg);
-    
+
     sprintf(log_buffer, "execing command (%s) args (%s)\n", shell, cmd.c_str());
     log_ext(-1, __func__, log_buffer, LOG_DEBUG);
     }
-  
+
   execve(shell, arg, job_env);
   } /* END launch_the_job_normally() */
 
@@ -4014,16 +4014,16 @@ void add_preexec_if_needed(
   if (PRE_EXEC[0] != '\0')
     {
     arg[aindex] = strdup(PRE_EXEC);
-    
+
     if (arg[aindex] == NULL)
       {
       log_err(errno, __func__, "cannot alloc env");
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
-    
+
     arg[aindex + 1] = NULL;
-    
+
     aindex++;
 
     *aindex_ptr = aindex;
@@ -4046,50 +4046,50 @@ void launch_the_demux(
   char *shellname;
   char *arg[MAX_JOB_ARGS];
   int   aindex;
-  
+
   /* setup descriptors 3 and 4 */
-  
+
   /* pjob->ji_stdout and pjob->ji_stderr were opened
    * in allocate_demux_sockets when we started this job */
   dup2(pjob->ji_stdout, 3);
-  
+
   if (pjob->ji_stdout > 3)
     close(pjob->ji_stdout);
-  
+
   dup2(pjob->ji_stderr, 4);
-  
+
   if (pjob->ji_stderr > 4)
     close(pjob->ji_stderr);
-  
-  /* construct argv array */  
+
+  /* construct argv array */
   shellname = strrchr((char *)demux, '/');
 
   if (shellname != NULL)
     ++shellname; /* go past last '/' */
   else
     shellname  = *shell_ptr;
-  
+
   aindex = 0;
-  
+
   arg[aindex] = (char *)calloc(1, strlen(shellname) + 1);
-  
+
   if (arg[aindex] == NULL)
     {
     log_err(errno, __func__, "cannot alloc env");
-    
+
     starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
     }
-  
+
   strcpy(arg[aindex], shellname);
-  
+
   arg[aindex + 1] = NULL;
-  
+
   aindex++;
 
   add_preexec_if_needed(arg, &aindex, sjr, TJE);
-  
+
   execve(demux, arg, vtable.v_envp);
-  
+
   /* reached only if execve fails */
   *shell_ptr = (char *)demux;  /* for fprintf below */
 
@@ -4100,7 +4100,7 @@ void launch_the_demux(
 
 
 void source_login_shells_or_not(
-    
+
   job                  *pjob,
   struct startjob_rtn  *sjr,
   pjobexec_t           *TJE,
@@ -4115,43 +4115,43 @@ void source_login_shells_or_not(
       ((TJE->is_interactive != TRUE) && (src_login_batch == FALSE)))
     {
     arg[aindex] = (char *)calloc(1, strlen(shellname) + 1);
-    
+
     if (arg[aindex] == NULL)
       {
       log_err(errno, __func__, "cannot alloc env");
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
-    
+
     strcpy(arg[aindex], shellname);
-    
+
     if (LOGLEVEL >= 7)
       {
       sprintf(log_buffer, "bypass sourcing of login files for job %s", pjob->ji_qs.ji_jobid);
-      
+
       log_ext(-1, __func__, log_buffer, LOG_DEBUG);
       }
-    
+
     }
   else
     {
     arg[aindex] = (char *)calloc(1, strlen(shellname) + 2);
-    
+
     if (arg[aindex] == NULL)
       {
       log_err(errno, __func__, "cannot alloc env");
-      
+
       starter_return(TJE->upfds, TJE->downfds, JOB_EXEC_FAIL2, sjr);
       }
-    
+
     /* specifying '-' indicates this is a 'login' shell */
     strcpy(arg[aindex], "-");
-    
+
     strcat(arg[aindex], shellname);
     }
-  
+
   arg[aindex + 1] = NULL;
-  
+
   aindex++;
   *aindex_ptr = aindex;
   } /* END source_login_shells_or_not() */
@@ -4334,6 +4334,12 @@ int TMomFinalizeChild(
     {
     pjob->ji_wattr[JOB_ATR_system_start_time].at_val.at_long = ps->start_time;
     pjob->ji_wattr[JOB_ATR_system_start_time].at_flags |= ATR_VFLAG_SET;
+    }
+
+  if(LOGLEVEL >= 7)
+    {
+    sprintf(log_buffer, "DRIFT debug: job start time = %ld, linux_time = %ld", ps->start_time, linux_time);
+    log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
     }
 
 #ifdef PENABLE_LINUX26_CPUSETS
@@ -4847,7 +4853,7 @@ int TMomFinalizeJob3(
       sprintf(buf, "%d", sjr.sj_rsvid);
       pjob->ji_wattr[JOB_ATR_reservation_id].at_val.at_str = strdup(buf);
       pjob->ji_wattr[JOB_ATR_reservation_id].at_flags = ATR_VFLAG_SET;
-    
+
       pjob->ji_wattr[JOB_ATR_pagg_id].at_val.at_ll = sjr.sj_jobid;
       pjob->ji_wattr[JOB_ATR_pagg_id].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODIFY;
       }
@@ -4876,7 +4882,7 @@ int TMomFinalizeJob3(
   sprintf(log_buffer, "job %s started, pid = %ld",
     pjob->ji_qs.ji_jobid,
     (long)sjr.sj_session);
-  
+
   log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, __func__, log_buffer);
 
   return(SUCCESS);
@@ -5570,7 +5576,7 @@ int start_process(
       sprintf(log_buffer, "PBS: chroot to %.256s failed: %s\n",
         idir,
         strerror(errno));
-      
+
       if (write_ac_socket(2, log_buffer, strlen(log_buffer)) == -1)
         {
         }
@@ -5903,10 +5909,10 @@ void job_nodes(
 
     nhosts++;
     }
-  
+
   pjob.ji_hosts = (hnodent *)calloc(nhosts + 1, sizeof(hnodent));
   pjob.ji_vnods = (vnodent *)calloc(nodenum + 1, sizeof(vnodent));
-  
+
   if ((pjob.ji_hosts == NULL) ||
       (pjob.ji_vnods == NULL))
     {
@@ -5927,14 +5933,14 @@ void job_nodes(
     // set pointer correctly
     pjob.ji_vnods[i].vn_host = &pjob.ji_hosts[pjob.ji_vnods[i].vn_node];
     pjob.ji_vnods[i].vn_node = i;
-      
+
     if (LOGLEVEL >= 4)
       {
       sprintf(log_buffer, "%d: %s/%d",
         pjob.ji_vnods[i].vn_node,
         pjob.ji_vnods[i].vn_host->hn_host,
         pjob.ji_vnods[i].vn_index);
-    
+
       log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, __func__, log_buffer);
       }
     }
@@ -5958,7 +5964,7 @@ void job_nodes(
       pjob.ji_qs.ji_jobid,
       nhosts,
       nodenum);
-    
+
     log_record(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, __func__, log_buffer);
     }
 
@@ -6186,7 +6192,7 @@ int send_join_job_to_a_sister(
 
 
 int send_join_job_to_sisters(
-    
+
   job        *pjob,
   int         nodenum,
   tlist_head  phead)
@@ -6203,9 +6209,9 @@ int send_join_job_to_sisters(
   int            unsent_count = nodenum - 1;
   bool           permanent_fail = false;
   std::set<int>  sisters_contacted;
-  
+
   errno = 0;
-    
+
   if (LOGLEVEL >= 7)
     {
     sprintf(log_buffer,"Sending join job to %d sisters.",unsent_count);
@@ -6238,13 +6244,13 @@ int send_join_job_to_sisters(
 
       ret = -1;
       stream = tcp_connect_sockaddr((struct sockaddr *)&np->sock_addr,sizeof(np->sock_addr));
-      
+
       if (IS_VALID_STREAM(stream))
         {
         ep = event_alloc(IM_JOIN_JOB, np, TM_NULL_EVENT, TM_NULL_TASK);
 
         ret = send_join_job_to_a_sister(pjob, stream, ep, phead, i);
-        
+
         close(stream);
         }
       else if (stream == PERMANENT_SOCKET_FAIL)
@@ -6301,9 +6307,9 @@ int send_join_job_to_sisters(
       }
 
     log_err(errno, __func__, log_buffer);
-    
+
     exec_bail(pjob, JOB_EXEC_RETRY, &sisters_contacted);
-    
+
     ret = PBSE_CANTCONTACTSISTERS;
     }
   else
@@ -6379,7 +6385,7 @@ void create_cpuset_reservation_if_needed(
   prd   = find_resc_def(svr_resc_def, "procs_bitmap", svr_resc_size);
   presc = find_resc_entry(&pjob.ji_wattr[JOB_ATR_resource],prd);
 
-  if ((presc == NULL) || 
+  if ((presc == NULL) ||
       (presc->rs_value.at_flags & ATR_VFLAG_SET) == FALSE)
     {
     /* this means there is no geometry request */
@@ -6538,36 +6544,36 @@ int start_exec(
     /* parallel job */
     mom_radix = pjob->ji_wattr[JOB_ATR_job_radix].at_val.at_long;
     }
-  
+
   pjob->ji_radix = mom_radix;
-  
+
   /* this starts tracking total run time for the MOM */
   pattr = &pjob->ji_wattr[JOB_ATR_total_runtime];
-  
+
   if (gettimeofday(&start_time, &tz) == 0)
     {
     pattr->at_val.at_timeval.tv_sec = start_time.tv_sec;
     pattr->at_val.at_timeval.tv_usec = start_time.tv_usec;
     }
-   
+
   /* If the job_radix pbs_attribute has been set then nodenum must be at least one
      more than mom_radix or there is no point in doing a radix */
-  if ((mom_radix > 0) && 
+  if ((mom_radix > 0) &&
       ((mom_radix + 1) <= nodenum) &&
       (is_login_node == FALSE))
     {
     noderes *pNodeRes = (noderes *)calloc(nodenum, sizeof(noderes));
-    
+
     assert(pNodeRes);
-    
+
     pNodeRes[0].nr_cput = 0;
     pNodeRes[0].nr_mem = 0;
     pNodeRes[0].nr_vmem = 0;
-    
+
     pjob->ji_resources = pNodeRes;
 
     pjob->ji_joins_sent = time(NULL);
-    
+
     if ((ret = allocate_demux_sockets(pjob, MOTHER_SUPERIOR)) != PBSE_NONE)
       return(ret);
 
@@ -6580,9 +6586,9 @@ int start_exec(
       }
 
     CLEAR_HEAD(phead);
-    
+
     pattr = pjob->ji_wattr;
-    
+
     /* prepare the attributes to go out on the wire. at_encode does this */
     for (i = 0;i < JOB_ATR_LAST;i++)
       {
@@ -6594,12 +6600,12 @@ int start_exec(
         ATR_ENCODE_MOM,
         ATR_DFLAG_ACCESS);
       }  /* END for (i) */
-    
+
     attrl_fixlink(&phead);
 
     pjob->ji_sisters = NULL;
     pjob->ji_numsisternodes = 0;
-    
+
     /* Parse nodes into the radix */
 
     /* First mother superior needs to keep track of the sisters that will
@@ -6608,12 +6614,12 @@ int start_exec(
      * This list will include mother superior and a list
      *  of hosts equal to the size of the job_radix. */
     sister_list = allocate_sister_list(mom_radix+1);
-    
+
     for (i = 0; i <= mom_radix; i++)
       {
       char           *host_addr = NULL;
       unsigned short  af_family;
-      
+
       np = &pjob->ji_hosts[i];
       add_host_to_sister_list(np->hn_host, np->hn_port, sister_list[0]);
       ret = get_hostaddr_hostent_af(&local_errno, np->hn_host, &af_family, &host_addr, &addr_len);
@@ -6622,27 +6628,27 @@ int start_exec(
       np->sock_addr.sin_family = af_family;
       free(host_addr);
       }
-    
+
     sister_job_nodes(pjob, sister_list[0]->host_list, sister_list[0]->port_list);
-    
+
     free_sisterlist(sister_list, mom_radix + 1);
-    
+
     /* The first element in the sister list will be the
        originator of the IM_JOIN_JOB_RADIX request. When
        the IM_OK_REPLY is received back the intermediate
        mothers need to know who called them so they can reply.
        This will always be the first sister in the list */
-    
+
     /* now allocate sister list for all the sisters */
     sister_list = allocate_sister_list(mom_radix);
-    
+
     np = &pjob->ji_hosts[0]; /* This is mother superior. Mother superior will be the first
                                 sister in the list */
     for (j = 0; j < mom_radix; j++)
       {
       add_host_to_sister_list(np->hn_host, np->hn_port, sister_list[j]);
       }
-    
+
     i = 1; /* Mother superior was the first entry, now start with the sisters */
     do
       {
@@ -6659,9 +6665,9 @@ int start_exec(
         add_host_to_sister_list(np->hn_host, np->hn_port, sister_list[j]);
         i++;
         }
-      
+
       } while (i < nodenum);
-    
+
     /* the sister lists have been made. Now contact the intermediate moms as designated by mom_radix */
     open_tcp_stream_to_sisters(
       pjob,
@@ -6672,7 +6678,7 @@ int start_exec(
       sister_list,
       &phead,
       MOTHER_SUPERIOR);
-    
+
     free_attrlist(&phead);
     free_sisterlist(sister_list, mom_radix);
     }
@@ -6681,11 +6687,11 @@ int start_exec(
     {
     /* Step 4.0A Send Join Request to Sisters */
     /* parallel job */
-    
+
     pjob->ji_resources = (noderes *)calloc(nodenum - 1, sizeof(noderes));
-    
+
     assert(pjob->ji_resources != NULL);
-    
+
     /* open a pair of sockets for pbs_demux used later */
     if ((ret = allocate_demux_sockets(pjob, MOTHER_SUPERIOR)) != PBSE_NONE)
       {
@@ -6699,9 +6705,9 @@ int start_exec(
 
       log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
       }
-    
+
     CLEAR_HEAD(phead);
-    
+
     pattr = pjob->ji_wattr;
 
     for (i = 0;i < JOB_ATR_LAST;i++)
@@ -6714,9 +6720,9 @@ int start_exec(
         ATR_ENCODE_MOM,
         ATR_DFLAG_ACCESS);
       }   /* END for (i) */
-    
+
     attrl_fixlink(&phead);
-    
+
     if (LOGLEVEL >= 7)
       {
       sprintf(log_buffer, "Sending join job to sisters succeeded at line %d\n",
@@ -6732,7 +6738,7 @@ int start_exec(
       }
 
     pjob->ji_joins_sent = time(NULL);
-    
+
     /* We made it to here. That means all of the sisters responded and we
        can now start the job */
     if (LOGLEVEL >= 6)
@@ -6741,18 +6747,18 @@ int start_exec(
         {
         tv_attr = &pjob->ji_wattr[JOB_ATR_total_runtime].at_val.at_timeval;
         timeval_subtract(&result, &tv, tv_attr);
-        sprintf(log_buffer, "%s: total wire-up time for job %ld.%ld", 
+        sprintf(log_buffer, "%s: total wire-up time for job %ld.%ld",
           __func__,
-          result.tv_sec, 
+          result.tv_sec,
           result.tv_usec);
-        
+
         log_event(PBSEVENT_JOB,PBS_EVENTCLASS_JOB,pjob->ji_qs.ji_jobid,log_buffer);
-        } 
+        }
       }
-    
+
     free_attrlist(&phead);
     /* The job will execute on mother superior when all sister nodes have replied */
-    
+
     }   /* END if (nodenum > 1) */
   else
 #endif /* ndef NUMA_SUPPORT */
@@ -6760,25 +6766,25 @@ int start_exec(
     /* Step 4.0B Launch Serial Task Locally */
 
     /* serial job */
-    
+
     /* single node job - no sisters */
-    
+
     pjob->ji_porterr = -1;
     pjob->ji_portout = -1;
     pjob->ji_stdout = -1;
     pjob->ji_stderr = -1;
-    
+
     if (exec_job_on_ms(pjob) == PBSE_NONE)
       {
       /* SUCCESS */
-      
+
       if (LOGLEVEL >= 3)
         {
         sprintf(log_buffer,"%s:job %s reported successful start on %d node(s)",
           __func__,
           pjob->ji_qs.ji_jobid,
           nodenum);
-        
+
         log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
         }
       }
@@ -6790,7 +6796,7 @@ int start_exec(
           __func__,
           pjob->ji_qs.ji_jobid,
           nodenum);
-        
+
         log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, pjob->ji_qs.ji_jobid, log_buffer);
         }
       }
@@ -6910,7 +6916,7 @@ void starter_return(
   if (code < 0)
     close(upfds);
 
-  /* 
+  /*
    * Wait for acknowledgement.  Need to allow for a timeout.  If it takes a while
    * to start the job which includes running prologues then the mom we are
    * communicating with may have timed out and gone into a recheck mode using
@@ -7412,13 +7418,13 @@ int open_std_file(
       getuid(),
       geteuid(),
       pjob->ji_qs.ji_un.ji_momt.ji_exuid);
-    
+
     log_ext(-1, __func__, log_buffer, LOG_DEBUG);
     }
 #ifdef __CYGWIN__
   if (IamRoot() == 1)
 #else
-  if ((getuid() == 0) && 
+  if ((getuid() == 0) &&
       (geteuid() != pjob->ji_qs.ji_un.ji_momt.ji_exuid))
 #endif
     {
@@ -7439,7 +7445,7 @@ int open_std_file(
         (unsigned long)pjob->ji_qs.ji_un.ji_momt.ji_exgid,
         (unsigned long)pjob->ji_qs.ji_un.ji_momt.ji_exuid,
         strerror(errno));
-      
+
       log_err(errno, __func__, log_buffer);
 
       return(-1);
@@ -7572,7 +7578,7 @@ int open_std_file(
     /* errno can change in functions called between here and the if check below */
     int local_errno = errno;
 
-    sprintf(log_buffer, 
+    sprintf(log_buffer,
       "cannot open/create stdout/stderr file '%s' (mode: %o, keeping: %s)",
       path,
       mode,
@@ -7597,10 +7603,10 @@ int open_std_file(
         *slash = '\0';
 
         mkdirtree(path,0755);
- 
+
         /* undo the marking of the end of path as NULL */
         *slash = '/';
-        
+
         if ((fds = open(path, mode, 0666)) != -1)
           {
           /* SUCCESS */
@@ -7612,17 +7618,17 @@ int open_std_file(
         {
         /* parent directory does not exist - find out what part of subtree exists */
         snprintf(tmpLine, sizeof(tmpLine), "%s", path);
-        
+
         while ((ptr = strrchr(tmpLine, '/')) != NULL)
           {
           *ptr = '\0';
-          
+
           if (lstat(tmpLine, &statbuf) == 0)
             {
             /* lstat succeeded */
-            
+
             sprintf(log_buffer, "'%s' exists\n", tmpLine);
-            
+
             break;
             }   /* END if (lstat(tmpLine,&statbuf) == 0) */
           else
@@ -7655,10 +7661,10 @@ int open_std_file(
         "seteuid(%lu) failed, error: %s\n",
         (unsigned long)pbsuser,
         strerror(errno));
-      
+
       log_err(errno, __func__, log_buffer);
       }
-    
+
     setegid(pbsgroup);
     }
 
@@ -7866,20 +7872,20 @@ int expand_vtable(
   int              amt = 0;
   struct var_table tmp_vtable;
   int              rc = PBSE_NONE;
-  
+
   if (vtable->v_ensize - vtable->v_used < EN_THRESHOLD)
     expand_ensize = 1;
-  
+
   if (vtable->v_bsize < B_THRESHOLD)
     expand_bsize = 1;
-  
+
   memset(&tmp_vtable, 0, sizeof(struct var_table));
-  
+
   if (expand_ensize)
     tmp_vtable.v_ensize = vtable->v_ensize + EN_THRESHOLD;
   else
     tmp_vtable.v_ensize = vtable->v_ensize; /* tmp holder for data copying */
-  
+
   tmp_vtable.v_envp = (char **)calloc(tmp_vtable.v_ensize, sizeof(char *));
   if (!tmp_vtable.v_envp)
     {
@@ -7888,9 +7894,9 @@ int expand_vtable(
     log_err(errno, __func__, log_buffer);
     return -1;
     }
-  
+
   tmp_vtable.v_used = vtable->v_used;
-  
+
   if (expand_bsize)
     {
     amt = EXTRA_VARIABLE_SPACE + (vtable->v_block - vtable->v_block_start) + vtable->v_bsize;
@@ -7898,7 +7904,7 @@ int expand_vtable(
     tmp_vtable.v_block = tmp_vtable.v_block_start;
     tmp_vtable.v_bsize = amt;
 
-    if (!tmp_vtable.v_block_start) 
+    if (!tmp_vtable.v_block_start)
       {
       sprintf(log_buffer, "PBS: failed to allocate memory for v_bsize: %s\n",
         strerror(errno));
@@ -7906,15 +7912,15 @@ int expand_vtable(
       return -1;
       }
     }
-  
+
   if ((rc = copy_data(&tmp_vtable, vtable, expand_bsize, expand_ensize) != PBSE_NONE))
     {
     if (tmp_vtable.v_block_start)
       free(tmp_vtable.v_block_start);
     if (tmp_vtable.v_envp)
-      free(tmp_vtable.v_envp); 
+      free(tmp_vtable.v_envp);
     }
-  
+
   return(rc);
   } /* END expand_vtable() */
 
@@ -7923,39 +7929,39 @@ int expand_vtable(
 int copy_data(
 
   struct var_table *tmp_vtable,
-  struct var_table *vtable, 
-  int               expand_bsize, 
+  struct var_table *vtable,
+  int               expand_bsize,
   int               expand_ensize)
-  
+
   {
   char *p_next_block;
   int   len_plus_one;
   int   i;
-  
+
   if (!expand_ensize && !expand_bsize )
     return(PBSE_NONE);
-  
+
   if (expand_ensize && (!expand_bsize))
-    { 
+    {
     /* only the pointers have been expanded and therefore copy
        the existing values to the new storage of pointers */
     for (i = 0; i < vtable->v_used; ++i)
-      *(tmp_vtable->v_envp + i) = *(vtable->v_envp + i); 
-    
+      *(tmp_vtable->v_envp + i) = *(vtable->v_envp + i);
+
     /* free the old storage and assign the new one */
     free(vtable->v_envp);
     vtable->v_envp = tmp_vtable->v_envp;
     vtable->v_ensize = tmp_vtable->v_ensize;
     }
   else if (expand_bsize)
-    { 
+    {
     /* block of memory that contains the actual env. variables was reallocated */
     p_next_block = tmp_vtable->v_block_start;
     for (i = 0; i < vtable->v_used; ++i)
       {
       len_plus_one = strlen(*(vtable->v_envp + i)) + 1;
       /* following condition is reached only for a non-null terminated variable */
-      if (len_plus_one > tmp_vtable->v_bsize) 
+      if (len_plus_one > tmp_vtable->v_bsize)
         {
         sprintf(log_buffer, "PBS: failed to copy env var, size: %d space left in buf: %d\n",
           len_plus_one, tmp_vtable->v_bsize);
@@ -7972,7 +7978,7 @@ int copy_data(
     vtable->v_bsize = tmp_vtable->v_bsize;
     vtable->v_block = p_next_block;
     free(vtable->v_block_start);
-    vtable->v_block_start = tmp_vtable->v_block_start; 
+    vtable->v_block_start = tmp_vtable->v_block_start;
 
     if (expand_ensize)
       {
@@ -7987,7 +7993,7 @@ int copy_data(
       /* copy the new location. Note all memory that had been allocated to
          tmp_vtable will be freed in the routine where they've been allocated */
       for (i = 0; i < vtable->v_used; ++i)
-        *(vtable->v_envp + i) = *(tmp_vtable->v_envp + i); 
+        *(vtable->v_envp + i) = *(tmp_vtable->v_envp + i);
       }
     }
 
@@ -8499,7 +8505,7 @@ int create_WLM_Rec(
   if (type == WM_INIT)
     {
     strcpy(rec_type, "init");
-    
+
     if (subtype == WM_INIT_START)
       {
       strcpy(sub_type, "start");
@@ -8517,7 +8523,7 @@ int create_WLM_Rec(
       sprintf(log_buffer, "WM_INIT bad sub type = %d for pbs job %s",
         subtype,
         pbs_jobid);
-      
+
       log_err(-1, __func__, log_buffer);
       return 0;
       }
@@ -8525,7 +8531,7 @@ int create_WLM_Rec(
   else if (type == WM_TERM)
     {
     strcpy(rec_type, "term");
-    
+
     if (subtype == WM_TERM_EXIT)
       {
       strcpy(sub_type, "exited");
@@ -8551,7 +8557,7 @@ int create_WLM_Rec(
       sprintf(log_buffer, "WM_TERM bad sub type = %d for pbs job %s",
         subtype,
         pbs_jobid);
-      
+
       log_err(-1, __func__, log_buffer);
       return 0;
       }
@@ -8559,7 +8565,7 @@ int create_WLM_Rec(
   else if (type == WM_RECV)
     {
     strcpy(rec_type, "recv");
-    
+
     if (subtype == WM_RECV_NEW)
       {
       strcpy(sub_type, "new");
@@ -8569,7 +8575,7 @@ int create_WLM_Rec(
       sprintf(log_buffer, "WM_RECV bad sub type = %d for pbs job %s",
         subtype,
         pbs_jobid);
-      
+
       log_err(-1, __func__, log_buffer);
       return 0;
       }
@@ -8579,11 +8585,11 @@ int create_WLM_Rec(
     sprintf(log_buffer, "bad record type = %d for pbs job %s",
       type,
       pbs_jobid);
-    
+
     log_err(-1, __func__, log_buffer);
     return 0;
     }
-  
+
 #ifdef CSAFAKE
   if (LOGLEVEL >= 7)
     {
@@ -8736,9 +8742,9 @@ void add_wkm_start(
         }
       return;
       }
-    
+
     /* Add a workload management received record before the start */
-    
+
     if (create_WLM_Rec(pbs_jobid, job_id, WM_RECV, WM_RECV_NEW, 0, 0, 0, 0))
       {
       if (LOGLEVEL >= 7)
@@ -8747,7 +8753,7 @@ void add_wkm_start(
           "Added CSA workload management WM_RECV for job id = %lx for pbs job %s",
           job_id,
           pbs_jobid);
-        
+
         log_ext(-1, __func__, log_buffer, LOG_DEBUG);
         }
       }
@@ -8759,13 +8765,13 @@ void add_wkm_start(
           "Failed to add CSA workload management WM_RECV for job id = %lx for pbs job %s",
           job_id,
           pbs_jobid);
-        
+
         log_err(-1, __func__, log_buffer);
         }
-      
+
       return;
       }
-    
+
     if (create_WLM_Rec(pbs_jobid, job_id, WM_INIT, WM_INIT_START, 0, 0, 0, 0))
       {
       if (LOGLEVEL >= 7)
@@ -8774,7 +8780,7 @@ void add_wkm_start(
           "Added CSA workload management WM_INIT for job id = %lx for pbs job %s",
           job_id,
           pbs_jobid);
-        
+
         log_ext(-1, __func__, log_buffer, LOG_DEBUG);
         }
       }
@@ -8784,7 +8790,7 @@ void add_wkm_start(
         "Failed to add CSA workload management WM_INIT for job id = %lx for pbs job %s",
         job_id,
         pbs_jobid);
-      
+
       log_err(-1, __func__, log_buffer);
       }
     } /* END if (check_csa_status(IS_UP)) */
@@ -8933,13 +8939,13 @@ int expand_path(
       /* fall through */
 
     default:
-        
+
       environ = environ_old;
 
       break;
 
     }  /* END switch () */
-        
+
   /* not reached */
   environ = environ_old;
 
@@ -9144,8 +9150,3 @@ done:
   } /* END allocate_demux_sockets() */
 
 /* END start_exec.c */
-
-
-
-
-

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -240,6 +240,8 @@ extern nodeboard      node_boards[MAX_NODE_BOARDS];
 extern int            numa_index;
 #endif
 
+extern int            linux_time;
+
 /* Local Variables */
 
 static int      script_in; /* script file, will be stdin   */


### PR DESCRIPTION
This is a workaround for #324.

A real fix would be to avoid the reliance on btime, instead tracking jiffies.

- added logging to track found time differences
- allow for a time difference up to 1 hour (3600 seconds).
- make sure qstat does something when run without arguments (see #322)

