### PR TITLE
Code cleanup for clean compilation

### DIFF
--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -572,6 +572,8 @@ public:
   unsigned char ttl[32];
   int          acl_size;
   std::string  rqid;
+
+  node_check_info() : first(NULL), first_status(NULL), state(0), ntype(0), nprops(0), nstatus(0), note(NULL), power_state(0), ttl(), acl_size(0), rqid() {}
   };
 
 

--- a/src/lib/Libattr/test/attr_node_func/Makefile.am
+++ b/src/lib/Libattr/test/attr_node_func/Makefile.am
@@ -8,11 +8,11 @@ AM_LDFLAGS = @CHECK_LIBS@ ${lib_LTLIBRARIES}
 
 check_PROGRAMS = test_attr_node_func
 
-libattr_node_func_la_SOURCES = scaffolding.c ${PROG_ROOT}/attr_node_func.c
-libattr_node_func_la_LDFLAGS = @CHECK_LIBS@ -shared -lgcov
+libattr_node_func_la_SOURCES = ${PROG_ROOT}/attr_node_func.c scaffolding.c
+libattr_node_func_la_LDFLAGS = @CHECK_LIBS@ -lgcov
 
-test_attr_node_func_SOURCES = test_attr_node_func.c
 test_attr_node_func_LDADD = ../../../../test/torque_test_lib/libtorque_test.la ../../../../test/scaffold_fail/libscaffold_fail.la
+test_attr_node_func_SOURCES = test_attr_node_func.c
 
 check_SCRIPTS = ${PROG_ROOT}/../../test/coverage_run.sh
 

--- a/src/lib/Libattr/test/attr_node_func/scaffolding.c
+++ b/src/lib/Libattr/test/attr_node_func/scaffolding.c
@@ -52,6 +52,7 @@ void populate_range_string_from_slot_tracker(
   std::string &range_str) 
   
   {
+	  return;
   }
 
 

--- a/src/lib/Libutils/u_mutex_mgr.cpp
+++ b/src/lib/Libutils/u_mutex_mgr.cpp
@@ -107,13 +107,9 @@ using namespace std;
   /* This constructor saves the given mutex and 
    * locks it  based on the value of is_locked
    */
-  mutex_mgr::mutex_mgr(pthread_mutex_t *mutex, bool is_locked) : managed_mutex(mutex), locked(is_locked)
+  mutex_mgr::mutex_mgr(pthread_mutex_t *mutex, bool is_locked) : unlock_on_exit(true), locked(is_locked), mutex_valid(true), managed_mutex(mutex)
     {
     int rc;
-
-    unlock_on_exit = true;
-    locked = is_locked;
-    mutex_valid = true;
 
     /* validate the mutex */
     if (mutex == NULL)

--- a/src/resmom/linux/numa_node.cpp
+++ b/src/resmom/linux/numa_node.cpp
@@ -152,10 +152,6 @@ void numa_node::get_cpuinfo(
   if (path == NULL)
     return;
 
-  unsigned int       total_cpus;
-  unsigned long      total_memory;
-  unsigned long      available_memory;
-  unsigned int       available_cpus;
 
   std::string   line;
   std::ifstream myfile(path);
@@ -456,13 +452,13 @@ unsigned int numa_node::get_my_index() const
 
 allocation::allocation(
 
-  const allocation &alloc) : memory(alloc.memory), cpus(alloc.cpus), cpu_indices(alloc.cpu_indices)
+  const allocation &alloc) : cpu_indices(alloc.cpu_indices), memory(alloc.memory), cpus(alloc.cpus), jobid()
 
   {
   strcpy(this->jobid, alloc.jobid);
   }
 
-allocation::allocation() : memory(0), cpus(0), cpu_indices()
+allocation::allocation() : cpu_indices(), memory(0), cpus(0), jobid()
 
   {
   this->jobid[0] = '\0';

--- a/src/resmom/test/mom_job_func/scaffolding.c
+++ b/src/resmom/test/mom_job_func/scaffolding.c
@@ -12,6 +12,7 @@
 #include "server_limits.h" /* pbs_net_t. Also defined in net_connect.h */
 #include "pbs_job.h" /* job_file_delete_info */
 #include "threadpool.h"
+#include "node_frequency.hpp"
 
 threadpool_t *request_pool;
 int is_login_node = 0;
@@ -141,4 +142,10 @@ char *pbse_to_txt(int err)
   fprintf(stderr, "The call to pbse_to_txt needs to be mocked!!\n");
   exit(1);
   }
+
+bool node_frequency::get_frequency_string(std::string& str,bool full)
+ {
+ return(false);
+ }
+
 

--- a/src/resmom/test/start_exec/scaffolding.c
+++ b/src/resmom/test/start_exec/scaffolding.c
@@ -25,6 +25,7 @@
 #include "node_internals.hpp"
 #endif
 
+unsigned linux_time = 0;
 int  send_ms_called;
 int  send_sisters_called;
 int  num_contacted;

--- a/src/server/execution_slot_tracker.cpp
+++ b/src/server/execution_slot_tracker.cpp
@@ -199,7 +199,7 @@ int execution_slot_tracker::reserve_execution_slots(
   while (est.get_total_execution_slots() < this->get_total_execution_slots())
     est.add_execution_slot();
 
-  for (int i = 0; i < this->slots.size() && reserved_so_far < num_slots_to_reserve; i++)
+  for (size_t i = 0; i < this->slots.size() && reserved_so_far < num_slots_to_reserve; i++)
     {
     if (this->slots[i] == FREE)
       {
@@ -230,7 +230,7 @@ int execution_slot_tracker::unreserve_execution_slots(
   if (this->slots.size() < subset.slots.size())
     return(SUBSET_TOO_LARGE);
 
-  for (int i = 0; i < subset.slots.size(); i++)
+  for (size_t i = 0; i < subset.slots.size(); i++)
     {
     if (subset.slots[i] == OCCUPIED)
       this->mark_as_free(i);

--- a/src/server/job_route.c
+++ b/src/server/job_route.c
@@ -368,7 +368,7 @@ int job_route(
       /* job may be acceptable */
 
       /* change for trq-2788, reroute even if -h */
-      if (!qp->qu_qs.qu_type == QTYPE_RoutePush)
+      if (qp->qu_qs.qu_type != QTYPE_RoutePush)
         bad_state = !qp->qu_attr[QR_ATR_RouteHeld].at_val.at_long;
 
       break;

--- a/src/test/torque_test_lib/test_tcp_dis.cpp
+++ b/src/test/torque_test_lib/test_tcp_dis.cpp
@@ -139,7 +139,6 @@ int tcp_read(
   int               tmp_leadp = 0;
   int               tmp_trailp = 0;
   int               tmp_eod = 0;
-  char              err_msg[1024];
 
   tcpData *data = fds[chan->sock];
 
@@ -267,12 +266,9 @@ int DIS_tcp_wflush(
   size_t            ct;
   int               i;
   char             *pb = NULL;
-  char             *pbs_debug = NULL;
 
   struct tcpdisbuf *tp;
   tcpData *data = fds[chan->sock];
-
-  pbs_debug = getenv("PBSDEBUG");
 
   tp = &chan->writebuf;
   pb = tp->tdis_thebuf;


### PR DESCRIPTION
I have cleaned up the code for a clean (no warnings) compilation on GCC 5.1.1

There are still some issues with the tests. The compilation isn't deterministic. Linking seems to fail intermittently (entering the affected directory and doing `make clean && make check` seems to fix it).