### PR TITLE
Remove unnecessary dependency on openssl-devel

### DIFF
--- a/README.building_40
+++ b/README.building_40
@@ -14,9 +14,6 @@ automake
 libtool
 pkg-config
 
-Non-standard packages required for building the source:
-libssl-dev (name may vary among OSes)
-
 *** For admins that use cpusets in any form ***
 hwloc version 1.1 or greater is now required for building TORQUE with cpusets, as pbs_mom now uses the 
 hwloc API to create the cpusets instead of creating them manually.

--- a/configure.ac
+++ b/configure.ac
@@ -745,16 +745,6 @@ AC_CHECK_LIB(pthread, pthread_create,
 LIBS="$LIBS $PTHREAD_LIBS"
 
 
-dnl we need -lssl and -lcrypto, lets make sure they exist
-AC_CHECK_LIB(ssl, SSL_accept,
-  [],
-  [AC_MSG_ERROR([TORQUE needs lib openssl-devel in order to build]) ])
-AC_CHECK_LIB(crypto, BN_init,
-  [],
-  [AC_MSG_ERROR([TORQUE needs lib crypto (often openssl-devel) in order to build]) ])
-
-
-
 dnl
 dnl we need libxml2
 dnl 

--- a/src/daemon_client/Makefile.am
+++ b/src/daemon_client/Makefile.am
@@ -5,7 +5,7 @@ CLEANFILES = *.gcda *.gcno *.gcov
 
 include_HEADERS = trq_auth_daemon.h
 
-AM_CFLAGS = -DPBS_SERVER_HOME=\"$(PBS_SERVER_HOME)\" -Wall -pthread -ldl -lrt -lssl -lcrypto
+AM_CFLAGS = -DPBS_SERVER_HOME=\"$(PBS_SERVER_HOME)\" -Wall -pthread -ldl -lrt
 
 sbin_PROGRAMS = trqauthd
 


### PR DESCRIPTION
My desktop was reinstalled with RHEL 7 and I came across this dependency.  If someone wants to actually use openssl functions, this can be reverted.  Closes #219