### PR TITLE
PBS_ARGS for pbs_sched and pbs_mom

### DIFF
--- a/contrib/init.d/pbs_mom.in
+++ b/contrib/init.d/pbs_mom.in
@@ -13,6 +13,7 @@ ulimit -n 32768
 SBIN_PATH=@sbindir@
 PBS_DAEMON="$SBIN_PATH/pbs_mom"
 PBS_HOME=@PBS_HOME@
+PBS_ARGS=""
 
 SUBSYS_LOCK="/var/lock/subsys/pbs_mom"
 
@@ -98,7 +99,7 @@ case "$1" in
 		fi
 
 		# ulimit -c unlimited  # Uncomment this to preserve core files
-		daemon $PBS_DAEMON $args -d $PBS_HOME
+		daemon $PBS_DAEMON $args -d $PBS_HOME $PBS_ARGS
 		RET=$?
 		touch $SUBSYS_LOCK
 		echo

--- a/contrib/init.d/pbs_sched.in
+++ b/contrib/init.d/pbs_sched.in
@@ -10,6 +10,7 @@
 
 PBS_DAEMON=@sbindir@/pbs_sched
 PBS_HOME=@PBS_HOME@
+PBS_ARGS=""
 export PBS_DAEMON PBS_HOME
 
 if [ -f /etc/sysconfig/pbs_sched ];then
@@ -24,7 +25,7 @@ case "$1" in
 		RET=$?
 		[ $RET -eq 0 ] && echo -n "pbs_sched already running" && success && echo && exit 0
 
-		daemon $PBS_DAEMON -d $PBS_HOME
+		daemon $PBS_DAEMON -d $PBS_HOME $PBS_ARGS
 		RET=$?
 		[ $RET -eq 0 ] && touch /var/lock/subsys/pbs_sched
 		echo


### PR DESCRIPTION
pbs_server allows you to have PBS_ARGS in /etc/sysconfig/pbs_server, however, pbs_mom and pbs_sched do not.

This should allow you to do so