### PR TITLE
(#329) Fix error message for failed interactive connection

### DIFF
--- a/src/lib/Libnet/net_client.c
+++ b/src/lib/Libnet/net_client.c
@@ -527,7 +527,7 @@ jump_to_check:
     err_buf[0] = '\0';
 
   fprintf(stderr, "INFO:  cannot connect to port %d, errno=%d - %s\n",
-    tryport,
+    port,
     errno,
     err_buf);
 #endif /* NDEBUG2 */


### PR DESCRIPTION
When the pbs_mom cannot connect to the qsub process, log the destination
port, not the source port that has already been bound.