### PR TITLE
Code cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2371,7 +2371,7 @@ drmaadocdir=$datadir/doc/$PACKAGE-drmaa
 AC_SUBST(drmaadocdir)
     
 if test "x$gccwarnings" = "xyes" ;then
-  AX_CFLAGS_GCC_OPTION([-W -Wall -Wextra -Wno-unused-parameter -Wno-long-long -pedantic -Werror])
+  AX_CFLAGS_GCC_OPTION([-W -Wall -Wextra -Wno-unused-parameter -Wno-long-long -pedantic -Werror -Wno-sign-compare])
 fi
 
 

--- a/src/cmds/MXML.c
+++ b/src/cmds/MXML.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include "pbs_helper.h"
 
 /* prototypes */
 
@@ -814,7 +815,7 @@ int MXMLToString(
   char     *Buf,           /* O */
   int       BufSize,       /* I */
   char    **Tail,          /* O */
-  mbool_t   IsRootElement) /* I */
+  mbool_t   UNUSED(IsRootElement)) /* I */
 
   {
   int index;

--- a/src/cmds/common_cmds.c
+++ b/src/cmds/common_cmds.c
@@ -9,6 +9,7 @@
 #include "pbs_error_db.h"
 #include <pbs_constants.h>
 #include <string>
+#include "pbs_helper.h"
 
 #define  JOB_ENV_START_SIZE 2048
 
@@ -237,9 +238,9 @@ void calloc_or_fail(
 
 int parse_variable_list(
   job_data_container *dest_hash, /* This is the dest hashmap for vars found */
-  job_data_container *user_env,  /* This is the source hashmap */
-  int                var_type,  /* Type for vars not pulled from the source hash */
-  int                op_type,   /* Op for vars not pulled from the source hash */
+  job_data_container * UNUSED(user_env),  /* This is the source hashmap */
+  int                  UNUSED(var_type),  /* Type for vars not pulled from the source hash */
+  int                  UNUSED(op_type),   /* Op for vars not pulled from the source hash */
   char               *the_list)  /* name=value,name1=value1,etc to be parsed */
 
   {

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -116,7 +116,7 @@
 #include        "cmds.h"
 #include "libcmds.h" /* TShowAbout_exit */
 #include "../lib/Libifl/lib_ifl.h"
-
+#include "pbs_helper.h"
 
 #define LIST 1
 #define CLEAR 2
@@ -485,7 +485,7 @@ const char *NState[] =
 
 int filterbystate(
 
-  struct batch_status *pbstat,
+  struct batch_status * UNUSED(pbstat),
   enum NStateEnum      ListType,
   char                *S)
 

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -71,6 +71,7 @@
 #include "qmgr.h"
 #include "net_cache.h"
 #include "../lib/Libifl/lib_ifl.h"
+#include "pbs_helper.h"
 
 
 
@@ -981,7 +982,7 @@ void clean_up_and_exit(int exit_val)
 void display(
 
   int                  otype,
-  char                *oname,
+  char                * UNUSED(oname),
   struct batch_status *status,
   int                  format)
 

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -1501,7 +1501,6 @@ void display_job_summary(
   const char          *format)
 
   {
-  struct attrl *a;
   unsigned int  len;
   char         *c = NULL;
   char         *jid = NULL;
@@ -1631,7 +1630,6 @@ void print_req_information(
 
   {
   mxml_t      *RE;
-  mxml_t      *AE;
   std::string  out;
   char         buf[100];
   char         name[1024];
@@ -1832,7 +1830,6 @@ void display_full_job(
 
   {
   struct attrl *attribute;
-  unsigned int  len;
   time_t        epoch;
 
   printf("Job Id: %s\n", p->name);
@@ -1937,7 +1934,6 @@ void display_statjob(
   {
   struct batch_status *p;
 
-  struct attrl        *a;
   char                 format[80];
 
   mxml_t              *DE;

--- a/src/cmds/qsub_functions.c
+++ b/src/cmds/qsub_functions.c
@@ -59,6 +59,7 @@
 #include "common_cmds.h" 
 #include "utils.h"
 #include "complete_req.hpp"
+#include "pbs_helper.h"
 
 #if defined(PBS_NO_POSIX_VIOLATION)
 #define GETOPT_ARGS "a:A:c:C:e:EF:hj:k:l:m:M:nN:o:p:q:r:S:u:v:VW:z"
@@ -1002,7 +1003,7 @@ void validate_basic_resourcing(
  */
 void validate_join_options (
   job_data_container *job_attr,
-  char               *script_tmp)
+  char               * UNUSED(script_tmp))
 
   {
 
@@ -1913,7 +1914,7 @@ void send_term(
 
 void catchchild(
 
-  int sig)
+  int UNUSED(sig) )
 
   {
   int status;
@@ -1962,7 +1963,7 @@ void catchchild(
 
 void no_suspend(
 
-  int sig)
+  int UNUSED(sig))
 
   {
   fprintf(stderr, "Sorry, you cannot suspend qsub until the job is started\n");
@@ -2021,7 +2022,7 @@ void bailout(void)
 
 void toolong(
 
-  int sig)
+  int UNUSED(sig))
 
   {
   printf("Timeout -- deleting job\n");
@@ -2037,7 +2038,7 @@ void toolong(
 
 void catchint(
 
-  int sig)
+  int UNUSED(sig))
 
   {
   int c;

--- a/src/daemon_client/trq_auth_daemon.c
+++ b/src/daemon_client/trq_auth_daemon.c
@@ -28,6 +28,7 @@
 #include "../lib/Liblog/pbs_log.h" /* logging stuff */
 #include "../include/log.h"  /* log events and event classes */
 #include "csv.h" /*csv_nth() */
+#include "pbs_helper.h"
 
 
 #define MAX_BUF 1024
@@ -90,7 +91,7 @@ int load_trqauthd_config(
   }
 
 int load_ssh_key(
-    char **ssh_key)
+    char ** UNUSED(ssh_key) )
   {
   int rc = PBSE_NONE;
   return rc;
@@ -381,7 +382,7 @@ int trq_main(
 
   int    argc,
   char **argv,
-  char **envp)
+  char ** UNUSED(envp))
 
   {
   int rc = PBSE_NONE;

--- a/src/include/pbs_helper.h
+++ b/src/include/pbs_helper.h
@@ -1,0 +1,15 @@
+#ifndef PBS_HELPER_H_
+#define PBS_HELPER_H_
+
+#ifdef UNUSED
+#elif defined(__GNUC__)
+# define UNUSED(x) UNUSED_ ## x __attribute__((unused))
+#elif defined(__LCLINT__)
+# define UNUSED(x) /*@unused@*/ x
+#elif defined(__cplusplus)
+# define UNUSED(x)
+#else
+# define UNUSED(x) x
+#endif
+
+#endif

--- a/src/lib/Libattr/attr_atomic.c
+++ b/src/lib/Libattr/attr_atomic.c
@@ -90,6 +90,7 @@
 #include "resource.h"
 #include "pbs_error.h"
 #include "pbs_job.h"
+#include "pbs_helper.h"
 
 #include "complete_req.hpp"
 
@@ -325,7 +326,7 @@ int attr_atomic_set(
 int attr_atomic_node_set(
 
   struct svrattrl *plist,    /* list of pbs_attribute modif structs */
-  pbs_attribute   *old,      /* unused */
+  pbs_attribute   * UNUSED(old),
   pbs_attribute   *new_attr,      /* new pbs_attribute array begins here */
   attribute_def   *pdef,     /* begin array  definition structs */
   int              limit,    /* number elts in definition array */

--- a/src/lib/Libattr/attr_fn_arst.c
+++ b/src/lib/Libattr/attr_fn_arst.c
@@ -79,6 +79,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains general function for attributes of type
@@ -269,10 +270,10 @@ int decode_arst_direct(
 int decode_arst(
 
   pbs_attribute *patr,    /* O (modified) */
-  const char   *name,    /* I pbs_attribute name (notused) */
-  const char *rescn,   /* I resource name (notused) */
+  const char *  UNUSED(name),    /* I pbs_attribute name (notused) */
+  const char *  UNUSED(rescn),   /* I resource name (notused) */
   const char    *val,     /* I pbs_attribute value */
-  int            perm) /* only used for resources */
+  int           UNUSED(perm)) /* only used for resources */
 
   {
   int           rc;
@@ -353,8 +354,8 @@ int decode_acl_arst(
 int decode_arst_merge(
 
   pbs_attribute *patr,    /* O (modified) */
-  const char   *name,    /* I pbs_attribute name (notused) */
-  const char *rescn,   /* I resource name (notused) */
+  const char * UNUSED(name),    /* I pbs_attribute name (notused) */
+  const char * UNUSED(rescn),   /* I resource name (notused) */
   const char    *val)     /* I pbs_attribute value */
 
   {
@@ -444,7 +445,7 @@ int encode_arst(
   const char   *atname, /* I pbs_attribute name */
   const char   *rsname, /* I resource name or NULL (optional) */
   int             mode,   /* I encode mode */
-  int             perm)   /* only used for resources */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
   char     *end;

--- a/src/lib/Libattr/attr_fn_attr_req_info.c
+++ b/src/lib/Libattr/attr_fn_attr_req_info.c
@@ -91,6 +91,7 @@
 #include "pbs_error.h"
 #include "attribute.h"
 #include "attr_req_info.hpp"
+#include "pbs_helper.h"
 
 /*
  * decode_attr_req_info()
@@ -112,7 +113,7 @@ int  decode_attr_req_info(
   const char    *name,
   const char    *rescn,
   const char    *val,
-  int            perm)
+  int            UNUSED(perm))
 
   {
   int rc = PBSE_NONE;
@@ -171,7 +172,7 @@ int encode_attr_req_info(
   pbs_attribute *attr,
   tlist_head    *phead,
   const char    *atname,
-  const char    *rsname,
+  const char    *UNUSED(rsname),
   int            mode,
   int            perm)
 

--- a/src/lib/Libattr/attr_fn_b.c
+++ b/src/lib/Libattr/attr_fn_b.c
@@ -90,6 +90,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -129,10 +130,10 @@ static const char *false_val = ATR_FALSE;
 int decode_b(
 
   pbs_attribute *patr,
-  const char    *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
   const char *src;
@@ -191,10 +192,10 @@ int encode_b(
 
   pbs_attribute  *attr,   /* ptr to pbs_attribute */
   tlist_head     *phead,  /* head of pbs_attribute list */
-  const char    *atname, /* pbs_attribute name */
-  const char    *rsname, /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)   /* only used for resources */
+  const char     *atname, /* pbs_attribute name */
+  const char     *rsname, /* resource name or null */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
   size_t   ct;

--- a/src/lib/Libattr/attr_fn_c.c
+++ b/src/lib/Libattr/attr_fn_c.c
@@ -90,6 +90,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes
@@ -123,10 +124,10 @@
 int decode_c(
 
   pbs_attribute *patr,
-  const char   *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
   if ((val == (char *)0) || (strlen(val) == 0))
@@ -159,8 +160,8 @@ int encode_c(
   tlist_head     *phead,  /* head of attrlist list */
   const char    *atname, /* pbs_attribute name */
   const char    *rsname, /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)   /* only used for resources */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
 

--- a/src/lib/Libattr/attr_fn_complete_req.c
+++ b/src/lib/Libattr/attr_fn_complete_req.c
@@ -89,7 +89,7 @@
 #include "complete_req.hpp"
 #include "attribute.h"
 #include "pbs_ifl.h"
-
+#include "pbs_helper.h"
 
 
 void free_complete_req(
@@ -125,10 +125,10 @@ void free_complete_req(
 int  decode_complete_req(
     
   pbs_attribute *patr,
-  const char    *name,
+  const char    * UNUSED(name),
   const char    *rescn,
   const char    *val,
-  int            perm)
+  int            UNUSED(perm))
 
   {
   if (val == NULL)
@@ -218,7 +218,7 @@ int encode_complete_req(
   pbs_attribute *attr,
   tlist_head    *phead,
   const char    *atname,
-  const char    *rsname,
+  const char    * UNUSED(rsname),
   int            mode,
   int            perm)
 
@@ -378,8 +378,8 @@ int set_complete_req(
 
 int comp_complete_req(
    
-  pbs_attribute *attr,
-  pbs_attribute *with)
+  pbs_attribute * UNUSED(attr),
+  pbs_attribute * UNUSED(with))
 
   {
   return(0);

--- a/src/lib/Libattr/attr_fn_freq.c
+++ b/src/lib/Libattr/attr_fn_freq.c
@@ -88,6 +88,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -126,10 +127,10 @@ void from_frequency(struct cpu_frequency_value *, char *);
 int decode_frequency(
 
   pbs_attribute *patr,
-  const char   *name, /* pbs_attribute name */
-  const char *rescn, /* resource name, unused here */
+  const char * UNUSED(name), /* pbs_attribute name */
+  const char * UNUSED(rescn), /* resource name, unused here */
   const char    *val, /* pbs_attribute value */
-  int            perm)  /* only used for resources */
+  int          UNUSED(perm))  /* only used for resources */
 
   {
 
@@ -172,11 +173,11 @@ int encode_frequency(
   tlist_head     *phead,   /* head of attrlist list */
   const char    *atname,  /* pbs_attribute name */
   const char    *rsname,  /* resource name (optional) */
-  int             mode,    /* encode mode (not used) */
-  int             perm)    /* only used for resources */
+  int            UNUSED(mode),    /* encode mode (not used) */
+  int            UNUSED(perm))    /* only used for resources */
 
   {
-  size_t    ct;
+  size_t   ct;
   char     cvnbuf[ENCODE_FREQUENCY_SIZE];
   svrattrl *pal;
 

--- a/src/lib/Libattr/attr_fn_hold.c
+++ b/src/lib/Libattr/attr_fn_hold.c
@@ -92,6 +92,7 @@
 #include "server_limits.h"
 #include "pbs_job.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 #define HOLD_ENCODE_SIZE 3
 
@@ -110,10 +111,10 @@
 int decode_hold(
 
   pbs_attribute *patr,
-  const char   *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name - unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name - unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
   const char  *pc;
@@ -174,8 +175,8 @@ int encode_hold(
   tlist_head     *phead,  /* head of attrlist */
   const char    *atname, /* name of pbs_attribute */
   const char    *rsname, /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)   /* only used for resources */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))   /* only used for resources */
 
 
   {

--- a/src/lib/Libattr/attr_fn_l.c
+++ b/src/lib/Libattr/attr_fn_l.c
@@ -88,6 +88,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -122,10 +123,10 @@
 int decode_l(
 
   pbs_attribute *patr,
-  const char  *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
   const char *pc;
@@ -177,8 +178,8 @@ int encode_l(
   tlist_head     *phead,  /* head of attrlist list */
   const char    *atname, /* pbs_attribute name */
   const char    *rsname, /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)   /* only used for resources */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
   size_t   ct;

--- a/src/lib/Libattr/attr_fn_ll.c
+++ b/src/lib/Libattr/attr_fn_ll.c
@@ -12,6 +12,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -48,10 +49,10 @@
 int decode_ll(
 
   pbs_attribute *patr,
-  const char   *name,  /* pbs_attribute name */
-  const char *rescn, /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn), /* resource name, unused here */
   const char    *val,   /* pbs_attribute value */
-  int            perm)  /* only used for resources */
+  int          UNUSED(perm))  /* only used for resources */
 
   {
   if ((val != (char *)0) && (strlen(val) != 0))
@@ -90,8 +91,8 @@ int encode_ll(
   tlist_head     *phead,   /* head of attrlist list */
   const char    *atname,  /* pbs_attribute name */
   const char    *rsname,  /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)  /* only used for resources */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))  /* only used for resources */
 
   {
   size_t   ct;

--- a/src/lib/Libattr/attr_fn_nppcu.c
+++ b/src/lib/Libattr/attr_fn_nppcu.c
@@ -88,6 +88,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 
 /*
@@ -101,10 +102,10 @@
 int decode_nppcu(
 
   pbs_attribute *patr,
-  const char  *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
   const char *pc;

--- a/src/lib/Libattr/attr_fn_resc.c
+++ b/src/lib/Libattr/attr_fn_resc.c
@@ -90,6 +90,7 @@
 #include "attribute.h"
 #include "resource.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -850,7 +851,7 @@ resource *add_resource_entry(
 int action_resc(
 
   pbs_attribute *pattr,
-  void          *pobject,
+  void          * UNUSED(pobject),
   int            actmode)
 
   {

--- a/src/lib/Libattr/attr_fn_size.c
+++ b/src/lib/Libattr/attr_fn_size.c
@@ -88,6 +88,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -129,10 +130,10 @@ int normalize_size(struct size_value *a, struct size_value *b,
 int decode_size(
 
   pbs_attribute *patr,
-  const char   *name, /* pbs_attribute name */
-  const char *rescn, /* resource name, unused here */
+  const char * UNUSED(name), /* pbs_attribute name */
+  const char * UNUSED(rescn), /* resource name, unused here */
   const char    *val, /* pbs_attribute value */
-  int            perm)  /* only used for resources */
+  int          UNUSED(perm))  /* only used for resources */
 
   {
 
@@ -176,8 +177,8 @@ int encode_size(
   tlist_head     *phead,   /* head of attrlist list */
   const char    *atname,  /* pbs_attribute name */
   const char    *rsname,  /* resource name (optional) */
-  int             mode,    /* encode mode (not used) */
-  int             perm)    /* only used for resources */
+  int            UNUSED(mode),    /* encode mode (not used) */
+  int            UNUSED(perm))    /* only used for resources */
 
   {
   size_t    ct;

--- a/src/lib/Libattr/attr_fn_str.c
+++ b/src/lib/Libattr/attr_fn_str.c
@@ -91,6 +91,7 @@
 #include "attribute.h"
 #include "pbs_error.h"
 #include "csv.h"
+#include "pbs_helper.h"
 
 using namespace std;
 /*
@@ -129,10 +130,10 @@ extern int ctnodes(char *spec);
 int decode_str(
 
   pbs_attribute *patr,   /* (I modified, allocated ) */
-  const char    *name,   /* (I - optional) pbs_attribute name */
-  const char    *rescn,  /* resource name - unused here */
+  const char * UNUSED(name),   /* (I - optional) pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name - unused here */
   const char    *val,    /* pbs_attribute value */
-  int            perm)   /* only used for resources */
+  int          UNUSED(perm))   /* only used for resources */
 
   {
   if (patr->at_val.at_str != NULL)
@@ -187,8 +188,8 @@ int encode_str(
   tlist_head     *phead,   /* head of attrlist */
   const char     *atname,  /* name of pbs_attribute */
   const char     *rsname,  /* resource name or null */
-  int             mode,    /* encode mode, unused here */
-  int             perm)    /* only used for resources */
+  int             UNUSED(mode),    /* encode mode, unused here */
+  int             UNUSED(perm))    /* only used for resources */
 
   {
   svrattrl *pal;

--- a/src/lib/Libattr/attr_fn_time.c
+++ b/src/lib/Libattr/attr_fn_time.c
@@ -89,6 +89,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of type
@@ -125,10 +126,10 @@
 int decode_time(
 
   pbs_attribute *patr,  /* I/O (modified) */
-  const char   *name,  /* I - pbs_attribute name (not used) */
-  const char *rescn, /* I - resource name (not used) */
+  const char * UNUSED(name),  /* I - pbs_attribute name (not used) */
+  const char * UNUSED(rescn), /* I - resource name (not used) */
   const char    *val,   /* I - pbs_attribute value */
-  int            perm)  /* only used for resources */
+  int          UNUSED(perm))  /* only used for resources */
 
   {
   int   i;
@@ -270,8 +271,8 @@ int encode_time(
   tlist_head     *phead,  /* head of attrlist list (optional) */
   const char    *atname, /* pbs_attribute name */
   const char    *rsname, /* resource name (optional) */
-  int             mode,   /* encode mode (not used) */
-  int             perm)  /* only used for resources */
+  int            UNUSED(mode),   /* encode mode (not used) */
+  int            UNUSED(perm))  /* only used for resources */
 
   {
   size_t    ct;

--- a/src/lib/Libattr/attr_fn_tv.c
+++ b/src/lib/Libattr/attr_fn_tv.c
@@ -89,6 +89,7 @@
 #include "attribute.h"
 #include "pbs_error.h"
 #include "pbs_job.h"
+#include "pbs_helper.h"
 
 int timeval_subtract( struct timeval *result, struct timeval *x, struct timeval *y);
 
@@ -126,10 +127,10 @@ int timeval_subtract( struct timeval *result, struct timeval *x, struct timeval 
 int decode_tv(
 
   pbs_attribute *patr,
-  const char   *name,  /* pbs_attribute name */
-  const char *rescn, /* resource name*/
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn), /* resource name*/
   const char    *val,   /* pbs_attribute value */
-  int            perm)  /* only used for resources */
+  int          UNUSED(perm))  /* only used for resources */
    
   {
   char 		*pc;
@@ -211,8 +212,8 @@ int encode_tv(
   tlist_head     *phead,  /* head of attrlist list (optional) */
   const char    *atname, /* pbs_attribute name */
   const char    *rsname, /* resource name (optional) */
-  int             mode,   /* endcode mode (not used) */
-  int             perm)   /* only used for resources */
+  int            UNUSED(mode),   /* endcode mode (not used) */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
   size_t 		 ct;

--- a/src/lib/Libattr/attr_fn_unkn.c
+++ b/src/lib/Libattr/attr_fn_unkn.c
@@ -91,6 +91,7 @@
 #include "attribute.h"
 #include "resource.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains functions for manipulating attributes of an
@@ -132,7 +133,7 @@ int decode_unkn(
   const char   *name,
   const char *rescn,
   const char    *value,
-  int            perm)  /* only used for resources */
+  int           UNUSED(perm))  /* only used for resources */
 
   {
   svrattrl *entry;
@@ -193,10 +194,10 @@ int encode_unkn(
 
   pbs_attribute  *attr,   /* ptr to pbs_attribute to encode */
   tlist_head     *phead,   /* list to place entry in */
-  const char    *atname,  /* pbs_attribute name, not used here */
-  const char    *rsname,  /* resource name, not used here */
-  int             mode,   /* encode mode, unused here */
-  int             perm)  /* only used for resources */
+  const char    * UNUSED(atname),  /* pbs_attribute name, not used here */
+  const char    * UNUSED(rsname),  /* resource name, not used here */
+  int             UNUSED(mode),   /* encode mode, unused here */
+  int             UNUSED(perm))  /* only used for resources */
 
   {
   svrattrl *plist;
@@ -278,7 +279,7 @@ int set_unkn(
    
   pbs_attribute *old,
   pbs_attribute *new_attr,
-  enum batch_op  op)
+  enum batch_op  UNUSED(op))
 
   {
   svrattrl *plist;
@@ -311,8 +312,8 @@ int set_unkn(
 
 int comp_unkn(
    
-  pbs_attribute *attr,
-  pbs_attribute *with)
+  pbs_attribute * UNUSED(attr),
+  pbs_attribute * UNUSED(with))
 
   {
   return (1);

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -87,6 +87,7 @@
 #include "list_link.h"
 #include "attribute.h"
 #include "pbs_error.h"
+#include "pbs_helper.h"
 
 /*
  * This file contains general functions for manipulating attributes.
@@ -262,7 +263,7 @@ void free_null(
 
 void free_noop(
 
-  pbs_attribute *attr)
+  pbs_attribute * UNUSED(attr))
 
   {
   /* no nothing */
@@ -280,8 +281,8 @@ void free_noop(
 
 int comp_null(
 
-  pbs_attribute *attr,   /* I */
-  pbs_attribute *with)   /* I */
+  pbs_attribute * UNUSED(attr),   /* I */
+  pbs_attribute * UNUSED(with))   /* I */
 
   {
   /* SUCCESS */

--- a/src/lib/Libattr/attr_node_func.c
+++ b/src/lib/Libattr/attr_node_func.c
@@ -104,6 +104,7 @@
 #include <syslog.h>
 #endif
 #include "id_map.hpp"
+#include "pbs_helper.h"
 
 extern int LOGLEVEL;
 void populate_range_string_from_slot_tracker(const execution_slot_tracker &est, std::string &range_str);
@@ -330,8 +331,8 @@ int encode_state(
                        which are to be returned*/
   const char   *aname, /*pbs_attribute's name    */
   const char   *rname, /*resource's name (null if none)  */
-  int            mode, /*mode code, unused here   */
-  int            perm) /* only used for resources */
+  int            UNUSED(mode), /*mode code, unused here   */
+  int            UNUSED(perm)) /* only used for resources */
 
   {
   int       i;
@@ -413,8 +414,8 @@ int encode_power_state(
                        which are to be returned*/
   const char   *aname, /*pbs_attribute's name    */
   const char   *rname, /*resource's name (null if none)  */
-  int            mode, /*mode code, unused here   */
-  int            perm) /* only used for resources */
+  int            UNUSED(mode), /*mode code, unused here   */
+  int            UNUSED(perm)) /* only used for resources */
 
   {
   svrattrl *pal;
@@ -499,8 +500,8 @@ int encode_ntype(
   tlist_head     *ph,    /*head of a list of  "svrattrl"   */
   const char    *aname, /*pbs_attribute's name    */
   const char    *rname, /*resource's name (null if none)  */
-  int             mode,  /*mode code, unused here   */
-  int             perm)  /* only used for resources */
+  int             UNUSED(mode),  /*mode code, unused here   */
+  int             UNUSED(perm))  /* only used for resources */
 
   {
   svrattrl *pal;
@@ -556,8 +557,8 @@ int encode_jobs(
                            which are to be returned*/
   const char    *aname, /*pbs_attribute's name    */
   const char    *rname, /*resource's name (null if none)  */
-  int             mode,  /*mode code, unused here   */
-  int             perm)  /* only used for resources */
+  int             UNUSED(mode),  /*mode code, unused here   */
+  int             UNUSED(perm))  /* only used for resources */
 
   {
   FUNCTION_TIMER
@@ -632,10 +633,10 @@ int encode_jobs(
 int decode_state(
 
   pbs_attribute *pattr,   /* I (modified) */
-  const char   *name,    /* pbs_attribute name */
-  const char *rescn,   /* resource name, unused here */
+  const char * UNUSED(name),    /* pbs_attribute name */
+  const char * UNUSED(rescn),   /* resource name, unused here */
   const char    *val,     /* pbs_attribute value */
-  int            perm)    /* only used for resources */
+  int          UNUSED(perm))    /* only used for resources */
 
   {
   int   rc = 0;  /*return code; 0==success*/
@@ -735,10 +736,10 @@ int decode_state(
 int decode_power_state(
 
   pbs_attribute *pattr,   /* I (modified) */
-  const char   *name,    /* pbs_attribute name */
-  const char *rescn,   /* resource name, unused here */
+  const char * UNUSED(name),    /* pbs_attribute name */
+  const char * UNUSED(rescn),   /* resource name, unused here */
   const char    *val,     /* pbs_attribute value */
-  int            perm)    /* only used for resources */
+  int          UNUSED(perm))    /* only used for resources */
 
   {
   int   flag = -1;
@@ -865,10 +866,10 @@ int decode_utc(
 int decode_ntype(
 
   pbs_attribute *pattr,
-  const char   *name,   /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),   /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,    /* pbs_attribute value */
-  int            perm)   /* only used for resources */
+  int          UNUSED(perm))   /* only used for resources */
 
 
   {

--- a/src/lib/Libattr/req.cpp
+++ b/src/lib/Libattr/req.cpp
@@ -294,8 +294,6 @@ int req::set_place_value(
     }
   else if (!strcmp(work_str, place_core))
     {
-    int count;
-
     if (numeric_value != NULL)
       rc = parse_positive_integer(numeric_value, this->cores);
     else
@@ -306,8 +304,6 @@ int req::set_place_value(
     }
   else if (!strcmp(work_str, place_thread))
     {
-    int count;
-
     if (numeric_value != NULL)
       rc = parse_positive_integer(numeric_value, this->threads);
     else

--- a/src/lib/Libutils/u_mutex_mgr.cpp
+++ b/src/lib/Libutils/u_mutex_mgr.cpp
@@ -107,13 +107,10 @@ using namespace std;
   /* This constructor saves the given mutex and 
    * locks it  based on the value of is_locked
    */
-  mutex_mgr::mutex_mgr(pthread_mutex_t *mutex, bool is_locked) : managed_mutex(mutex), locked(is_locked)
+  mutex_mgr::mutex_mgr(pthread_mutex_t *mutex, bool is_locked) 
+  : unlock_on_exit(true), locked(is_locked), mutex_valid(true), managed_mutex(mutex)
     {
     int rc;
-
-    unlock_on_exit = true;
-    locked = is_locked;
-    mutex_valid = true;
 
     /* validate the mutex */
     if (mutex == NULL)

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -973,7 +973,6 @@ bool mother_superior_cleanup(
 void scan_for_exiting(void)
 
   {
-  job          *nextjob;
   job          *pjob = NULL;
   int           found_one = 0;
 
@@ -2103,7 +2102,6 @@ int send_job_obit_to_ms(
   u_long       cput = resc_used(pjob, "cput", gettime);
   u_long       mem = resc_used(pjob, "mem", getsize);
   u_long       vmem = resc_used(pjob, "vmem", getsize);
-  u_long       joules = resc_used(pjob, "energy_used", gettime);
   int          command;
   tm_event_t   event;
   hnodent     *np;

--- a/src/resmom/linux/numa_node.cpp
+++ b/src/resmom/linux/numa_node.cpp
@@ -152,11 +152,6 @@ void numa_node::get_cpuinfo(
   if (path == NULL)
     return;
 
-  unsigned int       total_cpus;
-  unsigned long      total_memory;
-  unsigned long      available_memory;
-  unsigned int       available_cpus;
-
   std::string   line;
   std::ifstream myfile(path);
 

--- a/src/resmom/pbs_demux.c
+++ b/src/resmom/pbs_demux.c
@@ -103,6 +103,7 @@
 #  include <sys/select.h>
 #endif
 #include "../lib/Libifl/lib_ifl.h"
+#include "pbs_helper.h"
 
 
 enum rwhere {invalid, new_out, new_err, old_out, old_err};
@@ -188,7 +189,7 @@ static int demux_callback(void* arg)
 
 int main(
 
-  int   argc,
+  int   UNUSED(argc),
   char *argv[])
 
   {

--- a/src/resmom/requests.c
+++ b/src/resmom/requests.c
@@ -4180,7 +4180,7 @@ job *job_with_reservation_id(
   const char *rsv_id)
 
   {
-  job *pjob, *nxjob;
+  job *pjob;
   std::list<job *>::iterator iter;
 
   for (iter = alljobs_list.begin(); iter != alljobs_list.end(); iter++)

--- a/src/server/job_route.c
+++ b/src/server/job_route.c
@@ -368,7 +368,7 @@ int job_route(
       /* job may be acceptable */
 
       /* change for trq-2788, reroute even if -h */
-      if (!qp->qu_qs.qu_type == QTYPE_RoutePush)
+      if (qp->qu_qs.qu_type != QTYPE_RoutePush)
         bad_state = !qp->qu_attr[QR_ATR_RouteHeld].at_val.at_long;
 
       break;

--- a/src/server/resc_def_all.c
+++ b/src/server/resc_def_all.c
@@ -98,6 +98,7 @@
 #include "array.h"
 #include "utils.h"
 #include "svrfunc.h" /* get_svr_attr_* */
+#include "pbs_helper.h"
 
 extern struct server server;
 
@@ -1278,9 +1279,9 @@ int set_tokens_nodect(
 
 int set_mppnodect(
 
-  resource      *res,
+  resource      * UNUSED(res),
   pbs_attribute *attr,
-  int            op)
+  int             UNUSED(op))
 
   {
   int           width;
@@ -1368,10 +1369,10 @@ int set_mppnodect(
 int decode_procct(
 
   pbs_attribute *patr,
-  const char  *name,  /* pbs_attribute name */
-  const char *rescn,  /* resource name, unused here */
+  const char * UNUSED(name),  /* pbs_attribute name */
+  const char * UNUSED(rescn),  /* resource name, unused here */
   const char    *val,  /* pbs_attribute value */
-  int            perm) /* only used for resources */
+  int          UNUSED(perm)) /* only used for resources */
 
   {
     const char *pc;
@@ -1412,8 +1413,8 @@ int encode_procct(
   tlist_head     *phead,  /* head of attrlist list */
   const char    *atname, /* pbs_attribute name */
   const char    *rsname, /* resource name or null */
-  int             mode,   /* encode mode, unused here */
-  int             perm)   /* only used for resources */
+  int            UNUSED(mode),   /* encode mode, unused here */
+  int            UNUSED(perm))   /* only used for resources */
 
   {
   size_t   ct;


### PR DESCRIPTION
Cleaned up warnings caught with GCC 5. Mostly related to unused variables.

There is one actual bug fixed in src/server/job_route.c