### PR TITLE
pbsnodes does not change the note and node state (offline,online) atomically

### DIFF
--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -202,7 +202,7 @@ static int set_all_nodeattrs(
   {
   struct attropl *cur_pbsmanager_attr = NULL;
   struct attropl *cur_pbsmodify_attr = NULL;
-  struct attropl *tofree_pbsmanager_attr = NULL;
+  struct attropl *tofree_tmp_attr = NULL;
   char           *errmsg;
   int             rc = 0;
   int             local_errno = 0;
@@ -279,11 +279,11 @@ static int set_all_nodeattrs(
       }
 
     // Free attr allocation
-    tofree_pbsmanager_attr = cur_pbsmanager_attr;
+    tofree_tmp_attr = cur_pbsmanager_attr;
     cur_pbsmanager_attr = cur_pbsmanager_attr->next;
-    if (tofree_pbsmanager_attr)
+    if (tofree_tmp_attr)
       {
-      free(tofree_pbsmanager_attr);
+      free(tofree_tmp_attr);
       }
     }
 
@@ -291,11 +291,11 @@ static int set_all_nodeattrs(
   while (cur_pbsmodify_attr)
     {
     // Free attr allocation
-    tofree_pbsmanager_attr = cur_pbsmanager_attr;
+    tofree_tmp_attr = cur_pbsmodify_attr;
     cur_pbsmodify_attr = cur_pbsmodify_attr->next;
-    if (tofree_pbsmanager_attr)
+    if (tofree_tmp_attr)
       {
-      free(tofree_pbsmanager_attr);
+      free(tofree_tmp_attr);
       }
     }
 

--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -139,10 +139,11 @@ char *progname;
 
 mbool_t DisplayXML = FALSE;
 
-struct pbsnodes_node_attr {
-  struct attropl *pbsmanager_attrs;
-  struct attropl *pbsmodify_attrs;
-};
+struct pbsnodes_node_attr
+  {
+    struct attropl *pbsmanager_attrs;
+    struct attropl *pbsmodify_attrs;
+  };
 
 std::map<char *, struct pbsnodes_node_attr> node_attr_map;
 
@@ -154,33 +155,40 @@ std::map<char *, struct pbsnodes_node_attr> node_attr_map;
  *
  */
 static int set_last_attropl(
+
   struct attropl **attr_list,
-  struct attropl *new_attr
-  ) {
+  struct attropl *new_attr)
+
+  {
   struct attropl *last_attr = NULL;
 
   // new_attr is required and cannot be null
-  if (new_attr == NULL) {
+  if (new_attr == NULL)
+    {
     fprintf(stderr, "new_attr is not defined");
     return(1);
-  }
+    }
 
-  if (*attr_list == NULL) {
+  if (*attr_list == NULL)
+    {
     // First element added to the list
     *attr_list = new_attr;
     return(0);
-  } else {
+    }
+  else
+    {
     // Iterate to the tail of the linked list
     last_attr = *attr_list;
-    while (last_attr->next) {
+    while (last_attr->next)
+      {
       last_attr = last_attr->next;
-    }
+      }
     // Add new attribute to the tail of the linked list
     last_attr->next = new_attr;
-  }
+    }
 
   return(0);
-}
+  } /* END set_last_attropl() */
 
 
 /*
@@ -188,102 +196,111 @@ static int set_last_attropl(
  *
  */
 static int set_all_nodeattrs(
-  int    con
-  ) {
+
+  int    con)
+
+  {
   struct attropl *cur_pbsmanager_attr = NULL;
   struct attropl *cur_pbsmodify_attr = NULL;
   struct attropl *tofree_pbsmanager_attr = NULL;
   char           *errmsg;
   int             rc = 0;
   int             local_errno = 0;
-  char            *nodename;
+  char           *nodename;
 
   typedef std::map<char *, struct pbsnodes_node_attr>::iterator it_type;
   for(it_type iterator = node_attr_map.begin();
     iterator != node_attr_map.end();
-    iterator++) {
+    iterator++)
+    {
     nodename = iterator->first;
     cur_pbsmanager_attr = iterator->second.pbsmanager_attrs;
     cur_pbsmodify_attr = iterator->second.pbsmodify_attrs;
 
-    if ( cur_pbsmanager_attr ) {
-    rc = pbs_manager_err(
-         con,
-         MGR_CMD_SET,
-         MGR_OBJ_NODE,
-         nodename,
-         cur_pbsmanager_attr,
-         NULL,
-         &local_errno);
-
-    if (rc && !quiet)
-    {
-    fprintf(stderr, "Error setting note attribute for %s - ",
-      nodename);
-
-    if ((errmsg = pbs_geterrmsg(con)) != NULL)
+    if ( cur_pbsmanager_attr )
       {
-      fprintf(stderr, "%s\n", errmsg);
-      free(errmsg);
+      rc = pbs_manager_err(
+           con,
+           MGR_CMD_SET,
+           MGR_OBJ_NODE,
+           nodename,
+           cur_pbsmanager_attr,
+           NULL,
+           &local_errno);
+
+      if (rc && !quiet)
+        {
+        fprintf(stderr, "Error setting note attribute for %s - ",
+          nodename);
+
+        if ((errmsg = pbs_geterrmsg(con)) != NULL)
+          {
+          fprintf(stderr, "%s\n", errmsg);
+          free(errmsg);
+          }
+        }
       }
-    }
-    }
 
-    if ( cur_pbsmodify_attr ) {
-    rc = pbs_modify_node_err(
-         con,
-         MGR_CMD_SET,
-         MGR_OBJ_NODE,
-         nodename,
-         cur_pbsmodify_attr,
-         NULL,
-         &local_errno);
-
-    if (rc && !quiet)
-    {
-    fprintf(stderr, "Error setting node power state for %s - ",
-      nodename);
-
-      if ((errmsg = pbs_geterrmsg(con)) != NULL)
+    if ( cur_pbsmodify_attr )
       {
-      fprintf(stderr, "%s\n", errmsg);
-      free(errmsg);
-      }
-    }
-    }
-  }
+      rc = pbs_modify_node_err(
+           con,
+           MGR_CMD_SET,
+           MGR_OBJ_NODE,
+           nodename,
+           cur_pbsmodify_attr,
+           NULL,
+           &local_errno);
 
-  // Free Memory for Linked List
-  while (cur_pbsmanager_attr) {
-    // Free note allocation
-    if (cur_pbsmanager_attr->name) {
-      if (!strcmp(cur_pbsmanager_attr->name, ATTR_NODE_note)) {
-        if (cur_pbsmanager_attr->value) {
-          free(cur_pbsmanager_attr->value);
-          cur_pbsmanager_attr->value = NULL;
+      if (rc && !quiet)
+        {
+        fprintf(stderr, "Error setting node power state for %s - ",
+          nodename);
+
+        if ((errmsg = pbs_geterrmsg(con)) != NULL)
+          {
+          fprintf(stderr, "%s\n", errmsg);
+          free(errmsg);
+          }
         }
       }
     }
+
+  // Free Memory for Linked List
+  while (cur_pbsmanager_attr)
+    {
+    // Free note allocation
+    if (cur_pbsmanager_attr->name &&
+        strcmp(cur_pbsmanager_attr->name, ATTR_NODE_note) == 0 &&
+        cur_pbsmanager_attr->value)
+      {
+      free(cur_pbsmanager_attr->value);
+      cur_pbsmanager_attr->value = NULL;
+      }
+
     // Free attr allocation
     tofree_pbsmanager_attr = cur_pbsmanager_attr;
     cur_pbsmanager_attr = cur_pbsmanager_attr->next;
-    if (tofree_pbsmanager_attr) {
+    if (tofree_pbsmanager_attr)
+      {
       free(tofree_pbsmanager_attr);
+      }
     }
-  }
 
   // Free Memory for Linked List
-  while (cur_pbsmodify_attr) {
+  while (cur_pbsmodify_attr)
+    {
     // Free attr allocation
     tofree_pbsmanager_attr = cur_pbsmanager_attr;
     cur_pbsmodify_attr = cur_pbsmodify_attr->next;
-    if (tofree_pbsmanager_attr) {
+    if (tofree_pbsmanager_attr)
+      {
       free(tofree_pbsmanager_attr);
+      }
     }
-  }
 
   return(rc);
-}
+  }  /* END set_all_nodeattrs() */
 
 /*
  * set_note - set the note attribute for a node
@@ -299,10 +316,11 @@ static int set_note(
   struct attropl  *new_attr = NULL;
 
   new_attr = (struct attropl*)malloc(sizeof(struct attropl));
-  if ( new_attr == NULL && !quiet) {
+  if ( new_attr == NULL && !quiet)
+    {
     fprintf(stderr, "Failed to allocate new_attr");
     return(1);
-  }
+    }
 
   new_attr->name     = (char *)ATTR_NODE_note;
   new_attr->resource = NULL;
@@ -321,6 +339,7 @@ static int set_note(
  */
 
 static int set_node_power_state(
+
   char  *name,
   char  *power_state)
 
@@ -328,10 +347,11 @@ static int set_node_power_state(
   struct attropl *new_attr = NULL;
 
   new_attr = (struct attropl*)malloc(sizeof(struct attropl));
-  if ( new_attr == NULL  && !quiet ) {
+  if ( new_attr == NULL  && !quiet )
+    {
     fprintf(stderr, "Failed to allocate new_attr");
     return(1);
-  }
+    }
 
   new_attr->name     = (char *)ATTR_NODE_power_state;
   new_attr->resource = NULL;
@@ -430,10 +450,11 @@ static int marknode(
   int             rc;
 
   new_attr = (struct attropl*)malloc(sizeof(struct attropl));
-  if ( new_attr == NULL && !quiet ) {
-      fprintf(stderr, "Failed to allocate new_attr");
-      return(1);
-  }
+  if ( new_attr == NULL && !quiet )
+    {
+    fprintf(stderr, "Failed to allocate new_attr");
+    return(1);
+    }
 
   new_attr->name     = (char *)ATTR_NODE_state;
   new_attr->resource = NULL;

--- a/src/cmds/pbsnodes.h
+++ b/src/cmds/pbsnodes.h
@@ -18,10 +18,10 @@ enum NStateEnum
   tnsActive,       /* one or more jobs running on node */
   tnsAll,          /* list all nodes */
   tnsUp,           /* node is healthy */
-  tnsLAST             
+  tnsLAST
   };
 
-/* static int set_note(int con, char *name, char *msg); */
+/* static int set_note(char *name, char *msg); */
 
 /* static void prt_node_attr(struct batch_status *pbs, int IsVerbose);  */
 
@@ -29,7 +29,7 @@ enum NStateEnum
 
 /* static char *get_note(struct batch_status *pbs);  */
 
-/* static int marknode(int con, char *name, char *state1, enum batch_op op1, char *state2, enum batch_op op2); */
+/* static int marknode(char *name, char *state1, enum batch_op op1, char *state2, enum batch_op op2); */
 
 struct batch_status *statnode(int con, char *nodearg);
 


### PR DESCRIPTION
This issue was discovered by troubleshooting a problem where occasionally some nodes were marked offline without a note by nhc. Trying to determine the root cause I noticed in the logs of nhc, the following pbsnodes output: "Error marking node nodename......" that occurred when nodes were found offline without a note.  The way pbsnodes currently works (when given -c -N) is it calls set_note first and then marknode, which both call pbs_manager_err.  The bug happens when nhc runs "pbsnodes -c -N '' nodename" and pbs_manager_err succeeds for set_note and fails for marknode, this clears the note but does not put the node back online.  The fix is for pbsnodes to set the note and node state with a single pbs_manager_err call, which means both change atomically.  nhc works by marking a node offline and setting the note to "NHC: somecheck" when a node meets an error condition and brings it back online when the condition is resolved.  nhc only clears nodes marked offline by nhc (note must start with "NHC:"), so this bug causes nhc to leave nodes offline without a note and thus leaves nodes unavailable to users even though there is no current issue on the node.

I tested this change on a small 50 node cluster and was able to verify that the issue was repeatable with the current "pbsnodes" and that this change prevented nodes from ending up in the "offline without a note" state after a pbsnodes -c -N '' nodename command.