### PR TITLE
set_note_error endlessly appends notes to the node

### DIFF
--- a/src/server/process_mom_update.c
+++ b/src/server/process_mom_update.c
@@ -879,12 +879,12 @@ int process_status_info(
       }
     else if (!strncmp(str, "me", 2))  /* shorter str compare than "message" */
       {
-      if ((!strncmp(str, "message=PBS_ERROR:", 18)) &&
+      if ((!strncmp(str, "message=ERROR", 13)) &&
           (down_on_error == TRUE))
         {
         update_node_state(current, INUSE_DOWN);
         dont_change_state = TRUE;
-        set_note_error(current, str);
+        //set_note_error(current, str);
         }
       }
     else if (!strncmp(str,"macaddr=",8))

--- a/src/server/process_mom_update.c
+++ b/src/server/process_mom_update.c
@@ -879,7 +879,7 @@ int process_status_info(
       }
     else if (!strncmp(str, "me", 2))  /* shorter str compare than "message" */
       {
-      if ((!strncmp(str, "message=ERROR -", 15)) &&
+      if ((!strncmp(str, "message=PBS_ERROR:", 18)) &&
           (down_on_error == TRUE))
         {
         update_node_state(current, INUSE_DOWN);

--- a/src/server/process_mom_update.c
+++ b/src/server/process_mom_update.c
@@ -879,7 +879,7 @@ int process_status_info(
       }
     else if (!strncmp(str, "me", 2))  /* shorter str compare than "message" */
       {
-      if ((!strncmp(str, "message=ERROR", 13)) &&
+      if ((!strncmp(str, "message=ERROR -", 15)) &&
           (down_on_error == TRUE))
         {
         update_node_state(current, INUSE_DOWN);

--- a/src/test/process_mom_update/test_uut.c
+++ b/src/test/process_mom_update/test_uut.c
@@ -50,8 +50,8 @@ START_TEST(test_two)
 
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note");
-  fail_unless(set_note_error(pnode, "message=ERROR Everything's broken") == PBSE_NONE);
-  fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note - ERROR Everything's broken");
+  fail_unless(set_note_error(pnode, "message=ERROR - Everything's broken") == PBSE_NONE);
+  fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note - ERROR - Everything's broken");
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note");
   }

--- a/src/test/process_mom_update/test_uut.c
+++ b/src/test/process_mom_update/test_uut.c
@@ -11,24 +11,24 @@ int restore_note(struct pbsnode *np);
 START_TEST(test_set_note_error)
   {
   pbsnode pnode;
-  fail_unless(set_note_error(&pnode, "message=ERROR - bob") == PBSE_NONE, "Failed to append");
-  fail_unless(pnode.nd_note == "ERROR - bob");
+  fail_unless(set_note_error(&pnode, "message=PBS_ERROR: bob") == PBSE_NONE, "Failed to append");
+  fail_unless(pnode.nd_note == "PBS_ERROR: bob");
 
   // Make sure the same error isn't appended twice - the note shouldn't be changed
-  fail_unless(set_note_error(&pnode, "message=ERROR - bob") == PBSE_NONE);
-  fail_unless(pnode.nd_note == "ERROR - bob");
+  fail_unless(set_note_error(&pnode, "message=PBS_ERROR: bob") == PBSE_NONE);
+  fail_unless(pnode.nd_note == "PBS_ERROR: bob");
 
   pnode.nd_note.clear();
 
   fail_unless(set_note_error(&pnode, "message=yay") == PBSE_NONE);
   fail_unless(pnode.nd_note == "yay");
   
-  fail_unless(set_note_error(&pnode, "message=ERROR - the system is down") == PBSE_NONE);
-  fail_unless(pnode.nd_note == "yay - ERROR - the system is down");
+  fail_unless(set_note_error(&pnode, "message=PBS_ERROR: the system is down") == PBSE_NONE);
+  fail_unless(pnode.nd_note == "yay - PBS_ERROR: the system is down");
 
   // make sure newline stripped 
-  fail_unless(set_note_error(&pnode, "message=ERROR - the system is down\n") == PBSE_NONE);
-  fail_unless(pnode.nd_note == "yay - ERROR - the system is down");
+  fail_unless(set_note_error(&pnode, "message=PBS_ERROR: the system is down\n") == PBSE_NONE);
+  fail_unless(pnode.nd_note == "yay - PBS_ERROR: the system is down");
   }
 END_TEST
 
@@ -40,8 +40,8 @@ START_TEST(test_two)
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "");
 
-  fail_unless(set_note_error(pnode, "message=ERROR - bob") == PBSE_NONE);
-  fail_unless(pnode->nd_note == "ERROR - bob");
+  fail_unless(set_note_error(pnode, "message=PBS_ERROR: bob") == PBSE_NONE);
+  fail_unless(pnode->nd_note == "PBS_ERROR: bob");
 
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "");
@@ -50,8 +50,8 @@ START_TEST(test_two)
 
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note");
-  fail_unless(set_note_error(pnode, "message=ERROR - Everything's broken") == PBSE_NONE);
-  fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note - ERROR - Everything's broken");
+  fail_unless(set_note_error(pnode, "message=PBS_ERROR: Everything's broken") == PBSE_NONE);
+  fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note - PBS_ERROR: Everything's broken");
   fail_unless(restore_note(pnode) == PBSE_NONE);
   fail_unless(pnode->nd_note == "Yo Dawg, I heard you wanted a note");
   }


### PR DESCRIPTION
nhc (node health check) outputs to STDOUT "ERROR: some message" and has never caused any issues with torque release prior to 6.0.1. With torque 6.0.1 this is interpreted as an error to append to the note, this is not the desired or expected behavior.

Can you provide some background as to why this feature was needed? I don't want to break compatibility if this is a well documented and used feature.

I was not able to run the unit tests to verify this change doesn't break them, do you have instructions for running the unit tests?

-David