### PR TITLE
Mistake in the man page. down_on_error is currently true by default now.

### DIFF
--- a/doc/man7/pbs_server_attributes.7.in
+++ b/doc/man7/pbs_server_attributes.7.in
@@ -271,7 +271,7 @@ Format: boolean; default value: false.
 Set a node's state to "down" if MOM reports a message beginning with the string
 "ERROR".  This might interfere with moab's node error handling.  See the HEALTH
 CHECK section in pbs_mom(8B).  This is an EXPERIMENTAL feature and may be
-removed in the future.  Format: boolean; default value: false.
+removed in the future.  Format: boolean; default value: true.
 .if !\n(Pb .ig Ig
 [internal type: boolean]
 .Ig


### PR DESCRIPTION
The default value for down_on_error was changed in https://github.com/adaptivecomputing/torque/commit/f33c05a014d5f0d9e1b7b7226f0ce0e02f1e79a9#diff-f41edbf0d83389af469d191a7aa5b195. This change updates the documentation to reflect that change.

On another note, is this still an experimental feature as the man page says?