### PR TITLE
Check return code when moving tasks into a cpuset

### DIFF
--- a/src/resmom/linux/cpuset.c
+++ b/src/resmom/linux/cpuset.c
@@ -1609,8 +1609,12 @@ int move_to_job_cpuset(
     return(FAILURE);
     }
 
-  /* Success */
-  fclose(fd);
+  if (fclose(fd))
+    {
+    sprintf(log_buffer, "failed to move pid %d to cpuset %s", pid, cpuset_path);
+    log_err(errno, __func__, log_buffer);
+    return(FAILURE);
+    }
 
   if (LOGLEVEL >= 4)
     {


### PR DESCRIPTION
Most errors won't show up until you close the file.