### PR TITLE
re-initialize the torque cgroup subdirectories due to systemd cleanup of empty/unused cgroups

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -198,7 +198,8 @@ This package contains a DRMAA 1.0 implementation for use with TORQUE.
 CFLAGS="%{?cflags:%{cflags}}%{!?cflags:$RPM_OPT_FLAGS}"
 CXXFLAGS="%{?cxxflags:%{cxxflags}}%{!?cxxflags:$RPM_OPT_FLAGS}"
 export CFLAGS CXXFLAGS
-
+DOXYGEN=none
+export DOXYGEN
 %configure --includedir=%{_includedir}/%{name} --with-default-server=%{torque_server} \
     --with-server-home=%{torque_home} %{ac_with_debug} %{ac_with_libcpuset} \
     --with-sendmail=%{sendmail_path} %{ac_with_numa} %{ac_with_memacct} %{ac_with_top} \

--- a/src/include/trq_cgroups.h
+++ b/src/include/trq_cgroups.h
@@ -39,4 +39,5 @@ int trq_cg_get_task_cput_stats(const char *job_id, const unsigned int req_index,
 void trq_cg_delete_job_cgroups(const char *job_id, bool successfully_created);
 bool have_incompatible_dash_l_resource(job *pjob);
 int  trq_cg_add_devices_to_cgroup(job *pjob);
+int init_torque_cgroups();
 #endif /* _TRQ_CGROUPS_H_ */

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -2693,7 +2693,21 @@ int im_join_job_as_sister(
 #endif  /* (PENABLE_LINUX26_CPUSETS) */
 
 #ifdef PENABLE_LINUX_CGROUPS
-  ret = trq_cg_create_all_cgroups(pjob);
+  /*
+    Re-init the torque subdir
+   */
+  ret = init_torque_cgroups();
+  if (rc == PBSE_NONE) {
+      ret = trq_cg_create_all_cgroups(pjob);
+  } else {
+      /*
+        Send/log an additional error, cleanup and return as before
+       */
+    sprintf(log_buffer, "Could not init cgroups for job %s.", pjob->ji_qs.ji_jobid);
+    log_err(errno, __func__, log_buffer);
+    send_im_error(ret, 1, pjob, cookie, event, fromtask);
+  }
+
   if (ret != PBSE_NONE)
     {
     sprintf(log_buffer, "Could not create cgroups for job %s.", pjob->ji_qs.ji_jobid);


### PR DESCRIPTION
only creating the torque sub-cgroup during pbs_mom startup is not-sufficient. at least for memory and devices, it seems that systemd removes the sub-cgroup when no tasks are in it 

to reproduce 
```
[root@node2804 ~]# rpm -q systemd
systemd-219-19.el7_2.7.x86_64
[root@node2804 ~]# ls /sys/fs/cgroup/memory/woohoo | wc -l
ls: cannot access /sys/fs/cgroup/memory/woohoo: No such file or directory
0
[root@node2804 ~]# mkdir /sys/fs/cgroup/memory/woohoo
[root@node2804 ~]# ls /sys/fs/cgroup/memory/woohoo | wc -l
31
[root@node2804 ~]# systemctl daemon-reload
[root@node2804 ~]# systemctl restart autofs
[root@node2804 ~]# ls /sys/fs/cgroup/memory/woohoo | wc -l
ls: cannot access /sys/fs/cgroup/memory/woohoo: No such file or directory
0
```

(which service you restart is not relevant)

seems related to https://bugzilla.redhat.com/show_bug.cgi?id=1139223 (but that
was for cpu)

