### PR TITLE
4.2 dev fixcrash

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -1801,9 +1801,16 @@ job *chk_job_torun(
     {
     /* job has been checkpointed or files already staged in */
     /* in this case, exec_host must be already set          */
-
+    /* this is an unsafe assumption so let's be extra sure before doing strdup() */
     if (prun->rq_destin && *prun->rq_destin) /* If a destination has been specified */
       {
+      /* check that execution host is actually set */
+      /* this can happen if running the job failed after stagein */
+      if (pjob->ji_wattr[JOB_ATR_exec_host].at_val.at_str == NULL)
+	{
+	req_reject(PBSE_EXECTHERE, 0, preq, NULL, "exec host not set but files staged in");
+	return(NULL);
+	}
       /* specified destination must match exec_host */
       if ((exec_host = strdup(pjob->ji_wattr[JOB_ATR_exec_host].at_val.at_str)) == NULL)
         {

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -892,7 +892,7 @@ void release_node_allocation(
     pjob.ji_wattr[JOB_ATR_exec_host].at_val.at_str = NULL;
     pjob.ji_wattr[JOB_ATR_exec_host].at_flags &= ~ATR_VFLAG_SET;
     /* additionally clear the StagedIn flag if set */
-    pjob.ji_qs.ji_svrflags &= JOB_SVFLG_StagedIn;
+    pjob.ji_qs.ji_svrflags &= ~JOB_SVFLG_StagedIn;
     }
   } /* END release_node_allocation() */
 

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -891,6 +891,8 @@ void release_node_allocation(
     free(pjob.ji_wattr[JOB_ATR_exec_host].at_val.at_str);
     pjob.ji_wattr[JOB_ATR_exec_host].at_val.at_str = NULL;
     pjob.ji_wattr[JOB_ATR_exec_host].at_flags &= ~ATR_VFLAG_SET;
+    /* additionally clear the StagedIn flag if set */
+    pjob.ji_qs.ji_svrflags &= JOB_SVFLG_StagedIn;
     }
   } /* END release_node_allocation() */
 


### PR DESCRIPTION
Started taking 4.2.10 into production, and immediately ran into trouble. For some reason every now and again there is a miscommunication between the server and the mom which causes a failure to start a job. This happens after the files are already staged in. Due to the handling of the situation, a later attempt to rerun the job crashes the server.

The two commits make sure that the job is cleared of the stagedIn flag so it can be rerun, and guard against the unsafe assumption that exec_host will be set if the StagedIn flag is set.
