### PR TITLE
set node_name for logging the destination worker node instead of '???'

### DIFF
--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -713,6 +713,11 @@ int send_job_work(
     resc_access_perm = ATR_DFLAG_MOM;
     encode_type = ATR_ENCODE_MOM;
     cntype = ToServerDIS;
+    /* node_name is NULL when passed through send_job_to_mom */
+    if (node_name == NULL && strlen(job_destin) > 0)
+	{
+	    node_name = job_destin;
+	}
     }
   else
     {


### PR DESCRIPTION
All starting jobs produce a line in the log file like

    child reported success for job after 1 seconds (dest=???), rc=0

The three question marks are due to `node_name` not being set. This small patch sets the node_name from the destination.