### PR TITLE
Fix build

### DIFF
--- a/src/lib/Libutils/numa_pci_device.cpp
+++ b/src/lib/Libutils/numa_pci_device.cpp
@@ -36,7 +36,7 @@ PCI_Device::PCI_Device() : name(), id(-1), info_name(), info_value(), nearest_cp
   }
 
 PCI_Device::PCI_Device(
-    
+
   const PCI_Device &other) : name(other.name), id(other.id), info_name(other.info_name),
                              info_value(other.info_value), type(other.type), busy(other.busy)
 
@@ -66,6 +66,7 @@ PCI_Device::~PCI_Device()
   memset(cpuset_string, 0, MAX_CPUSET_SIZE);
   }
 
+#ifdef NVIDIA_GPUS
 void PCI_Device::initializeGpu(
 
   int              idx,
@@ -107,6 +108,7 @@ void PCI_Device::initializeGpu(
     this->type = GPU;
 
   }
+#endif
 
 int PCI_Device::initializePCIDevice(hwloc_obj_t device_obj, int idx, hwloc_topology_t topology)
   {
@@ -138,9 +140,9 @@ void PCI_Device::displayAsString(
   {
   out << "      pci " << this->id << " " << this->name << "\n";
   } // end displayasstring()
-  
+
 void PCI_Device::setName(
-    
+
   const string &name)
 
   {
@@ -148,7 +150,7 @@ void PCI_Device::setName(
   }
 
 void PCI_Device::setId(
-  
+
   int id)
 
   {
@@ -195,4 +197,4 @@ int PCI_Device::get_id() const
   return(this->id);
   }
 
-#endif /* PENABLE_LINUX_CGROUPS */   
+#endif /* PENABLE_LINUX_CGROUPS */


### PR DESCRIPTION
Build failed with

~~~~
g++ -DHAVE_CONFIG_H -I. -I../../../src/include  -I../../../src/include `xml2-config --cflags` -I/usr/include  -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic -c -o numa_pci_device.o numa_pci_device.cpp
numa_pci_device.cpp:72:28: error: no 'void PCI_Device::initializeGpu(int, hwloc_topology_t)' member function declared in class 'PCI_Device'
   hwloc_topology_t topology)
                            ^
make[4]: *** [numa_pci_device.o] Error 1
make[4]: Leaving directory `/home/ageorges/rpmbuild/BUILD/torque-6.0/src/lib/Libutils'
make[3]: *** [all-recursive] Error 1
make[3]: Leaving directory `/home/ageorges/rpmbuild/BUILD/torque-6.0/src/lib/Libutils'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/home/ageorges/rpmbuild/BUILD/torque-6.0/src/lib'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/ageorges/rpmbuild/BUILD/torque-6.0/src'
make: *** [all-recursive] Error 1
error: Bad exit status from /var/tmp/rpm-tmp.OnoHFn (%build)
~~~~