### PR TITLE
Fix a crash in the ALPS reporter mom if apbasil_protocol is unset

### DIFF
--- a/src/resmom/generate_alps_status.c
+++ b/src/resmom/generate_alps_status.c
@@ -1053,7 +1053,7 @@ int generate_alps_status(
         log_event(PBSEVENT_JOB | PBSEVENT_SYSLOG, PBS_EVENTCLASS_JOB, __func__, log_buffer);
         }
 
-      if (!strcmp(apbasil_protocol, "1.7"))
+      if ((apbasil_protocol != NULL) && !strcmp(apbasil_protocol, "1.7"))
         rc = get_knl_information(apbasil_path);
         
       if (rc == PBSE_NONE)


### PR DESCRIPTION
On a new system we left $apbasil_protocol unset and the reporter mom segfaults.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff5952b5a in __strcmp_sse2_unaligned () from /lib64/libc.so.6
Missing separate debuginfos, use: zypper install libgcc_s1-debuginfo-5.2.1+r226025-4.1.x86_64 liblzma5-debuginfo-5.0.5-4.852.x86_64 libopenssl1_0_0-debuginfo-1.0.1i-27.6.1.x86_64 libstdc++6-debuginfo-5.2.1+r226025-4.1.x86_64 libxml2-2-debuginfo-2.9.1-17.1.x86_64 libz1-debuginfo-1.2.8-5.1.x86_64
(gdb) bt
#0  0x00007ffff5952b5a in __strcmp_sse2_unaligned () from /lib64/libc.so.6
#1  0x000000000047d212 in generate_alps_status (status=..., apbasil_path=0x11b5cc0 "/opt/cray/alps/default/bin/apbasil", apbasil_protocol=0x0)
    at generate_alps_status.c:1056
#2  0x000000000044c06b in mom_server_all_update_stat () at mom_server.c:1688
#3  0x0000000000447380 in main_loop () at mom_main.c:6486
#4  0x000000000044787e in main (argc=2, argv=0x7fffffffd448) at mom_main.c:7088
```