### PR TITLE
drop remainafterexit in pbs_server unit file

### DIFF
--- a/contrib/systemd/pbs_server.service.in
+++ b/contrib/systemd/pbs_server.service.in
@@ -7,7 +7,6 @@ After=trqauthd.service network.target local-fs.target rsyslog.target
 [Service]
 Type=simple
 User=root
-RemainAfterExit=yes
 
 # Let systemd guess the pid.
 #


### PR DESCRIPTION
RemainAfterExit will keep the unit active even if no processes are running anymore (instead of failed).

From the man-page:
```
RemainAfterExit=

    Takes a boolean value that specifies whether the service shall be considered active even when all its processes exited. Defaults to no.
```