### PR TITLE
Add macro for LDFLAGS (like for CFLAGS)

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -197,7 +197,7 @@ This package contains a DRMAA 1.0 implementation for use with TORQUE.
 %build
 CFLAGS="%{?cflags:%{cflags}}%{!?cflags:$RPM_OPT_FLAGS}"
 CXXFLAGS="%{?cxxflags:%{cxxflags}}%{!?cxxflags:$RPM_OPT_FLAGS}"
-LDFLAGS="%{?ldflags:%{ldflags}}%{!?ldflags:@LDFLAGS@}"
+LDFLAGS="%{?ldflags:%{ldflags}}%{!?ldflags:$RPM_LD_FLAGS}"
 export CFLAGS CXXFLAGS LDFLAGS
 # use cached configure DOXYGEN
 export ac_cv_path_DOXYGEN=none

--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -197,7 +197,8 @@ This package contains a DRMAA 1.0 implementation for use with TORQUE.
 %build
 CFLAGS="%{?cflags:%{cflags}}%{!?cflags:$RPM_OPT_FLAGS}"
 CXXFLAGS="%{?cxxflags:%{cxxflags}}%{!?cxxflags:$RPM_OPT_FLAGS}"
-export CFLAGS CXXFLAGS
+LDFLAGS="%{?ldflags:%{ldflags}}%{!?ldflags:@LDFLAGS@}"
+export CFLAGS CXXFLAGS LDFLAGS
 # use cached configure DOXYGEN
 export ac_cv_path_DOXYGEN=none
 %configure --includedir=%{_includedir}/%{name} --with-default-server=%{torque_server} \


### PR DESCRIPTION
If no other ldflag is definied, use the LDFLAGS value passed on to the
configure script.