### PR TITLE
Also let user specify rpmbuild options to source build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,7 @@ dist-hook:
 	sed -e 's/TORQUE .* README .*/TORQUE $(VERSION) README (released '"`date '+%b, %d %Y'`"')/' $(srcdir)/README.torque > $(distdir)/README.torque
 
 srpm: dist
-	rpmbuild -ts $(distdir).tar.gz
+	rpmbuild $(RPMOPTS) -ts $(distdir).tar.gz
 
 rpm: dist
 	rpmbuild $(RPM_AC_OPTS) $(RPMOPTS) -tb $(distdir).tar.gz


### PR DESCRIPTION
Now you can do things like: `make RPMOPTS='--define "_topdir /my/top/dir"'`. 

Please also cherry pick to 6.0-dev.