### PR TITLE
Do not recheck the result of pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1272,8 +1272,6 @@ If you have done these and still get this  error, try running ./autogen.sh and
 then configuring again.
 ])])
 
-      AC_CHECK_LIB([hwloc], [hwloc_linux_get_tid_last_cpu_location],,
-        [AC_MSG_ERROR([libhwloc does not look like >= 1.9])])
     fi
 
     LIBS="$LIBS $HWLOC_LIBS";


### PR DESCRIPTION
Currently, pkg-config is used to find hwloc >= 1.9 but the result is
then ignored to check the hwloc library. This will cause it to fail if
there is a newer hwloc on a non-standard location.