### PR TITLE
I have updated the configure logic to reject anything other than the …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1397,7 +1397,7 @@ AS_IF([test -z "$with_pmix" || test "$with_pmix" = "no"],
                                                   #endif
                                                   ], [])],
                                 [AC_MSG_RESULT([found])
-                                 pmix_version=3X
+                                 pmix_version=3
                                  pmix_version_found=1],
                                 [AC_MSG_RESULT([not found])])])
 
@@ -1410,7 +1410,7 @@ AS_IF([test -z "$with_pmix" || test "$with_pmix" = "no"],
                                                   #endif
                                                   ], [])],
                                 [AC_MSG_RESULT([found])
-                                 pmix_version=2X
+                                 pmix_version=2
                                  pmix_version_found=1],
                                 [AC_MSG_RESULT([not found])])])
 
@@ -1423,11 +1423,11 @@ AS_IF([test -z "$with_pmix" || test "$with_pmix" = "no"],
                                                   #endif
                                                   ], [])],
                                 [AC_MSG_RESULT([found])
-                                 pmix_version=1X
+                                 pmix_version=1
                                  pmix_version_found=1],
                                 [AC_MSG_RESULT([not found])])])
 
-       AS_IF([test "x$pmix_version" = "x"],
+       AS_IF([test "x$pmix_version" = "x" || test "$pmix_version" != "1"],
              [AC_MSG_WARN([PMIx support requested, but version])
               AC_MSG_WARN([information of the external lib could not])
               AC_MSG_WARN([be detected])
@@ -1445,6 +1445,7 @@ if test "${build_mom}" = "yes" ; then
     if test "${pmix_happy}" = "yes"; then
       AC_MSG_RESULT([yes - version: $pmix_version])
       AC_DEFINE([ENABLE_PMIX], 1, [Define to enable pmix support])
+      AC_DEFINE([PMIX_VERSION], [$pmix_version], [The PMIx version we are building against])
       CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
       LDFLAGS="-L$pmix_ext_install_dir/lib $LDFLAGS"
       MOMLIBS="$MOMLIBS -lpmix"

--- a/src/resmom/pmix_interface.c
+++ b/src/resmom/pmix_interface.c
@@ -28,9 +28,7 @@ bool pmix_spawn_timed_out;
 pmix_status_t pmix_client_connect(
 
   const pmix_proc_t *proc,
-  void              *svr_obj,
-  pmix_op_cbfunc_t   cbfunc,
-  void              *cbdata)
+  void              *svr_obj)
 
   {
   pmix_status_t  rc = PMIX_SUCCESS;
@@ -49,9 +47,6 @@ pmix_status_t pmix_client_connect(
     }
   else
     rc = PMIX_ERR_NOT_FOUND;
-
-  if (cbfunc != NULL)
-    cbfunc(rc, cbdata);
 
   return(rc);
   } // END pmi_client_connect()
@@ -160,7 +155,7 @@ bool check_and_record_fence(
     pmix_operation fence(pjob, procs, nprocs, info, cbfunc, cbdata);
     pending_fences[jobid] = fence;
     }
-    
+
   return(pending_fences[jobid].mark_reported(mom_host));
   } // END check_and_record_fence()
 
@@ -491,7 +486,7 @@ pmix_status_t pmix_server_spawn(
   time_t            start_time;
   time_t            global_tcp_timeout = 0;
   //bool            notify = false;
-  
+
   memset(&timeout, 0, sizeof(timeout));
 
   if (pjob == NULL)
@@ -512,7 +507,7 @@ pmix_status_t pmix_server_spawn(
         notify = true;
         } */
       }
-    
+
     if (timeout.tv_sec != 0)
       {
       start_time = time(NULL);
@@ -677,12 +672,10 @@ pmix_status_t pmix_server_disconnect(
 
 pmix_status_t pmix_server_register_events(
 
-  pmix_status_t     *codes,
-  size_t             ncodes,
-  const pmix_info_t  info[],
-  size_t             ninfo,
-  pmix_op_cbfunc_t   cbfunc,
-  void              *cbdata)
+  const pmix_info_t     info[],
+  size_t                ninfo,
+  pmix_op_cbfunc_t      cbfunc,
+  void                  *cbdata)
 
   {
   return(PMIX_ERR_NOT_SUPPORTED);
@@ -692,66 +685,16 @@ pmix_status_t pmix_server_register_events(
 
 pmix_status_t pmix_server_deregister_events(
 
-  pmix_status_t     *codes,
-  size_t             ncodes,
-  pmix_op_cbfunc_t   cbfunc,
-  void              *cbdata)
+  const pmix_info_t     info[],
+  size_t                ninfo,
+  pmix_op_cbfunc_t      cbfunc,
+  void                  *cbdata)
 
   {
   return(PMIX_ERR_NOT_SUPPORTED);
   } // END pmix_server_deregister_event()
 
-pmix_status_t pmix_server_notify_event(
-
-  pmix_status_t      code,
-  const pmix_proc_t *source,
-  pmix_data_range_t  range,
-  pmix_info_t        info[],
-  size_t             ninfo,
-  pmix_op_cbfunc_t   cbfunc,
-  void              *cbdata)
-
-  {
-  return(PMIX_ERR_NOT_SUPPORTED);
-  } // END pmix_server_notify_event()
-
-pmix_status_t pmix_server_query(
-
-  pmix_proc_t        *proct,
-  pmix_query_t       *queries,
-  size_t              nqueries,
-  pmix_info_cbfunc_t  cbfunc,
-  void               *cbdata)
-
-  {
-  return(PMIX_ERR_NOT_SUPPORTED);
-  } // END pmix_server_query()
-
-void pmix_server_tool_connection(
-
-  pmix_info_t                   *info,
-  size_t                         ninfo,
-  pmix_tool_connection_cbfunc_t  cbfunc,
-  void                          *cbdata)
-
-  {
-  } // END pmix_server_tool_connection()
-
-void pmix_server_log(
-
-  const pmix_proc_t *client,
-  const pmix_info_t  data[],
-  size_t             ndata,
-  const pmix_info_t  directives[],
-  size_t             ndirectives,
-  pmix_op_cbfunc_t   cbfunc,
-  void              *cbdata)
-
-  {
-  }
-
-
-pmix_server_module_t psm = 
+pmix_server_module_t psm =
   {
   pmix_client_connect,
   pmix_client_finalize,
@@ -765,12 +708,7 @@ pmix_server_module_t psm =
   pmix_server_connect,
   pmix_server_disconnect,
   pmix_server_register_events,
-  pmix_server_deregister_events,
-  pmix_server_notify_event,
-  NULL, // instructs pmix server to listen by it's lonesome
-  pmix_server_query,
-  pmix_server_tool_connection,
-  pmix_server_log
+  pmix_server_deregister_events
   };
 
 


### PR DESCRIPTION
…PMIx v1.1.5 (or something further along the v1 series, should we release something) as that is the only release out there today. Future releases can be supported with the appropriate #if checks for PMIX_VERSION in the code.

I found a race condition in the PMIx integration that registers nspaces and clients. The PMIx APIs for that purpose are non-blocking, but they must complete prior to you fork/exec'ing any local clients. Otherwise, a connection request that arrives at the PMIx server prior to completing the registration functions will be rejected.

I don't know your threading model enough to figure out how to implement the wait function, so I left some comments (they start with "RHC" so you can search for them) that explain what needs to be done. Hopefully, those will be clear enough to get you thru the problem. If not, feel free to holler.