### PR TITLE
Support hwloc path in rpm build

### DIFF
--- a/buildutils/torque.spec.in
+++ b/buildutils/torque.spec.in
@@ -61,9 +61,9 @@
 %define ac_trqauthd_sock_dir %{?trqauthd_sock_dir:%{trqauthd_sock_dir}}%{!?trqauthd_sock_dir:/tmp}
 
 ### Build Requirements
-%define breq_cpuset   %{?with_cpuset:hwloc-devel}
+%define breq_cpuset   %{!?hwloc_path:%{?with_cpuset:hwloc-devel}}
 %define breq_gui      %{?with_gui:tcl-devel tk-devel tclx}
-%define breq_numa     %{?with_cpuset:hwloc-devel}
+%define breq_numa     %{!?hwloc_path:%{?with_cpuset:hwloc-devel}}
 %define breq_munge    %{?with_munge:munge-devel}
 %define breq_pam      %{?with_pam:pam-devel}
 %define breq_readline %{?with_readline:readline-devel}
@@ -204,7 +204,7 @@ export ac_cv_path_DOXYGEN=none
 %configure --includedir=%{_includedir}/%{name} --with-default-server=%{torque_server} \
     --with-server-home=%{torque_home} %{ac_with_debug} %{ac_with_libcpuset} \
     --with-sendmail=%{sendmail_path} %{ac_with_numa} %{ac_with_memacct} %{ac_with_top} \
-    --with-trqauthd-sock-dir=%{ac_trqauthd_sock_dir} %{?xauth_path:--with-xauth=%{xauth_path}} \
+    --with-trqauthd-sock-dir=%{ac_trqauthd_sock_dir} %{?xauth_path:--with-xauth=%{xauth_path}} %{?hwloc_path:--with-hwloc-path=%{hwloc_path}} \
     --disable-dependency-tracking %{ac_with_gui} %{ac_with_scp} %{ac_with_syslog} \
     --disable-gcc-warnings %{ac_with_munge} %{ac_with_pam} %{ac_with_drmaa} \
     --disable-qsub-keep-override %{ac_with_blcr} %{ac_with_cpuset} %{ac_with_cgroups} %{ac_with_spool} %{?acflags}

--- a/configure.ac
+++ b/configure.ac
@@ -1166,7 +1166,7 @@ AC_ARG_WITH(hwloc-path, [
                        Example: ./configure --with-hwloc-path=/usr/local/hwloc-1.9
                        Will specify that the include files are in /usr/local/hwloc-1.9/include and
                        the libraries are in /usr/local/hwloc-1.9/lib],
-  [HWLOC_LIBS="-L${withval}/lib -lhwloc"; HWLOC_CFLAGS="-I${withval}/include"],
+  [HWLOC_LIBS="-L${withval}/lib -lhwloc"; HWLOC_CFLAGS="-I${withval}/include"; RPM_AC_OPTS="$RPM_AC_OPTS --define \"hwloc_path ${withval}\""],
   [TOM="BOB"])
 
 


### PR DESCRIPTION
When building hwloc from source (eg. el6), you can specify a custom path
using `--with-hwloc-path`. The rpm build did not take this option into account.

Added the necessary entries in configure.ac and the spec file for it to
work.