### PR TITLE
Let pbstop parser read consecutive index jobs

### DIFF
--- a/contrib/pbstop
+++ b/contrib/pbstop
@@ -459,7 +459,13 @@ sub get_info_modPBS {
             $name eq $PBS::ATTR_NODE_jobs and do {
                 $State_count->{"_anodes"}++;
                 foreach my $job ( split ( /, /, $value ) ) {
-                    if ( $job =~ m{(\d+)/(\d+)} ) {
+                    if ( $job =~ m{(\d+)-(\d+)/(\d+)} ) {
+                        for ( my $i = $1; $i <= $2; $i++ ) {
+                            $Nodes->{$server}{$node}{job}{$i} = $3;
+                            $State_count->{"_aprocs"}++;
+                        }
+                    }
+                    elsif ( $job =~ m{(\d+)/(\d+)} ) {
                         $Nodes->{$server}{$node}{job}{$1} = $2;
                         $State_count->{"_aprocs"}++;
                     }
@@ -555,7 +561,13 @@ sub get_info_cmdline {
             $jobs = $1;
             $State_count->{"_anodes"}++;
             foreach my $job ( split ( /, /, $jobs ) ) {
-                if ( $job =~ m{(\d+)/(\d+)} ) {
+                if ( $job =~ m{(\d+)-(\d+)/(\d+)} ) {
+                    for ( my $i = $1; $i <= $2; $i++ ) {
+                        $Nodes->{$server}{$node}{job}{$i} = $3;
+                        $State_count->{"_aprocs"}++;
+                    }
+                }
+                elsif ( $job =~ m{(\d+)/(\d+)} ) {
                     $Nodes->{$server}{$node}{job}{$1} = $2;
                     $State_count->{"_aprocs"}++;
                 }
@@ -577,7 +589,13 @@ sub get_info_cmdline {
               /^\s+(.*)$/;
               $jobs = $1;
               foreach my $job ( split ( /, /, $jobs ) ) {
-                if ( $job =~ m{(\d+)/(\d+)} ) {
+                if ( $job =~ m{(\d+)-(\d+)/(\d+)} ) {
+                    for ( my $i = $1; $i <= $2; $i++ ) {
+                        $Nodes->{$server}{$node}{job}{$i} = $3;
+                        $State_count->{"_aprocs"}++;
+                    }
+                }
+                elsif ( $job =~ m{(\d+)/(\d+)} ) {
                     $Nodes->{$server}{$node}{job}{$1} = $2;
                     $State_count->{"_aprocs"}++;
                 }


### PR DESCRIPTION
The pbstop contrib tool parses the output of 'qmgr -l -n' and
uses the information to display a grid of the cluster which shows
where jobs are running.

It seems that starting with commit 1573753 the format of the job
list returned by pbsnodes/qmgr changed so that multiple core jobs
was condensed and this borke the pbstop parsing algorithm. This is
a simple patch that will recognize the new format.

The format for the "jobs" attribute of a node was:
0/JOB1, 1/JOB1, 2/JOB1, 3/JOB2

Now it is:
0-2/JOB1, 3/JOB2

I wasn't able to test the modPBS routine but the format should be the same.