### PR TITLE
contrib/pbs_service: correct directive typo

### DIFF
--- a/contrib/systemd/pbs_sched.service.in
+++ b/contrib/systemd/pbs_sched.service.in
@@ -11,7 +11,7 @@ User=root
 # Do not set PIDFile via enviroment PBS_HOME
 # better to change to PIDFile=/var/run/%i.pid
 # and cleanup all code that relies on the current location of the PIDFile
-PIDFILE=@PBS_HOME@/sched_priv/sched.lock
+PIDFile=@PBS_HOME@/sched_priv/sched.lock
 
 Environment=PBS_HOME=@PBS_HOME@
 Environment=PBS_ARGS=


### PR DESCRIPTION
* PIDFILE -> PIDFile
  section names are directives are case sensitive

Looked for contributing guidelines but did find anything.