### PR TITLE
Reset fromlen before each accept() call

### DIFF
--- a/src/lib/Libnet/port_forwarding.c
+++ b/src/lib/Libnet/port_forwarding.c
@@ -46,7 +46,7 @@ void port_forwarder(
   torque_socklen_t fromlen;
   int n, n2, sock;
 
-  fromlen = sizeof(from);
+  
 
   while (1)
     {
@@ -102,7 +102,8 @@ void port_forwarder(
         if ((socks + n)->listening)
           {
           int newsock = 0, peersock = 0;
-
+          fromlen = sizeof(from);
+          
           if ((sock = accept((socks + n)->sock, (struct sockaddr *) & from, &fromlen)) < 0)
             {
             if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINTR) || (errno == ECONNABORTED))


### PR DESCRIPTION
Accept() will only write fromlen bytes to the buffer it is given, but will then set fromlen to the number of bytes it wanted to write. This causes subsequent calls to write past the from buffer onto stack variables, noticeably the n loop counter which causes a segfault. Fix resets fromlen before each accept() call.