### PR TITLE
Include stdbool.h in pbs_ifl.h

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -87,6 +87,10 @@
 #define _PBS_IFL_DEF
 #include <sys/socket.h>
 
+#ifdef __cplusplus
+#include <stdbool.h>
+#endif /* __cplusplus */
+
 /* Attribute Names used by user commands */
 
 #define ATTR_a "Execution_Time"


### PR DESCRIPTION
Needed to build things like pbs-drmaa (http://apps.man.poznan.pl/trac/pbs-drmaa)