### PR TITLE
Trim down on zeros in PCI domain for sysfs

### DIFF
--- a/src/resmom/accelerators_numa.cpp
+++ b/src/resmom/accelerators_numa.cpp
@@ -214,10 +214,16 @@ void PCI_Device::initializeGpu(
     log_err(-1, __func__, log_buffer);
     return;
     }
+
+  string busId = pci.busId;
+
+  // if it starts with 8 zeros, cut it down to 4 zeros for sysfs
+  if (busId.substr(0,8) == "00000000")
+    busId = busId.substr(4);
    
   // build path to cpulist for this PCI device
   snprintf(cpulist_path, sizeof(cpulist_path), "/sys/bus/pci/devices/%s/local_cpulist",
-    pci.busId);
+    busId.c_str());
 
   // open cpulist
   if ((fp = fopen(cpulist_path, "r")) == NULL)


### PR DESCRIPTION
NVML returns `00000000` as PCI domain while sysfs uses `0000`. This patch trims the 8 zeros to 4 to read from sysfs.

For example, on our system NVML returned: `00000000:82:00.0` while the sysfs path was `0000:82:00.0`.

I'm not entirely sure if this is the right approach. Maybe first try to read the full path and only then fall back to the one with the trimmed zeros?

Please backport to 6.1.2.