### PR TITLE
Always use primary group for initgroups

### DIFF
--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -586,7 +586,7 @@ int check_pwd(
     }
 
   if ((pjob->ji_grpcache->gc_ngroup = init_groups( pwdp->pw_name,
-                           pjob->ji_qs.ji_un.ji_momt.ji_exgid,
+                           pwdp->pw_gid,
                            NGROUPS_MAX,
                            pjob->ji_grpcache->gc_groups)) < 0)
     {


### PR DESCRIPTION
When users are not members of their primary group[1], initgroups(3) being called with the group listed in the group_list parameter causes the primary group to be missing in supplemental group list for the launched job. 

This change will cause init_groups to always call initgroups(3) with the user's primary group so that it will continue to exist later on when setgid is called with the group from the group_list. 

Redacted example:
```
[user@login ~] # groups
primarygrp secondarygrp

# Unpatched node:
[user@login ~] # qsub -I -W group_list=secondarygrp
[user@compute ~] groups
secondarygrp

# Patched node:
[user@login ~] # qsub -I -W group_list=secondarygrp
[user@compute ~] groups
secondarygrp primarygrp
```

[1] Happens when the user's entry in LDAP assigns them to a group, but they aren't added to the group member list.