### PR TITLE
configure.ac: Fix _FORTIFY_SOURCE macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1475,7 +1475,7 @@ if test "x$GCC" = "xyes" ;then
   AC_MSG_CHECKING([whether add memory alignment flags])
   if test "${enable_align_memory}" = "yes" ; then
     AC_MSG_RESULT([yes])
-    CFLAGS="$CFLAGS -fstack-protector -Wformat -Wformat-security -DFORTIFY_SOURCE=2"
+    CFLAGS="$CFLAGS -fstack-protector -Wformat -Wformat-security -D_FORTIFY_SOURCE=2"
   else
     AC_MSG_RESULT([no])
   fi


### PR DESCRIPTION
This commit fixes the mistake in the `_FORTIFY_SOURCE` macro where it was not prefixed with underscore while it has to be (see e.g. https://github.com/search?q=repo%3Abminor%2Fglibc%20FORTIFY_SOURCE&type=code).

Additionally, to make this macro add extra security, one has to enable optimizations. I am not sure if the configure enables them, but it is worth double checking that as well.

Overall, I would recommend using `-D_FORTIFY_SOURCE=3` with  `-O2` or `-O3`. (The fortify source level 3 was added recently and you can read more about it here: https://developers.redhat.com/blog/2021/04/16/broadening-compiler-checks-for-buffer-overflows-in-_fortify_source).

You can also see the result of the correct vs incorrect macro along with optimizations and no optimizations on this screenshot ([source](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIM6SuADJ4DJgAcj4ARpjEIABspAAOqAqETgwe3r7%2ByanpAiFhkSwxcYl2mA4ZQgRMxARZPn4BldUCtfUERRHRsQm2dQ1NOa1D3aG9pf3xAJS2qF7EyOwc5gDMocjeWADUJutuCgTEocAAdAgH2CYaAIK3d6EEuyxMoRDPu8ik3wj1ACpdvVgAA3EwAVisEIAIrN9gB2Kz3XZ/eq7KJeKiQixcDSQmEHZF3VHHZZJACeEExVF%2BIPBUPxsNmRMeJgRMI481onAhvD8HC0pFQnDc1msuwUi2WmH2ZnWPFIBE0XPmAGsJPFzhD1gAOLgKgCc8TMZmNkkN%2Bk4kn5KuFnF4ChAGiVKvmcFgMCgXogSDQLCSdFi5Eo/sD9DiwC4ptIWFBeBWADU8JgAO4AeSSjE4ipotAIsSd1LtUVC9QpOd4/rYgnTDFoFcFvCwbyM4ibsbwxCqjlBmCdHcwqiqXgLduemB5HdoeCixHLHiwdpOeBYlfmVAMwAUybTmez3F4/EEIjE7CkMkEihU6g7umkBiMKHFln0s6dkHmqCSjgEA4AtDCAD6ABi6YAEoACoAJIgQAmkBQjpnI4FuDc6wwlwuz/umiptL%2BfgQK4Ix%2BFwgQMOgPQlGUegpGkBEkbR%2BQEVRfRxGR%2BE1OMjEcZOPZcV0rHTOxgxdDxokNEJNFcPMUpLCsEjcrytodiKHC7KourxP%2B8SSLswDIMguzRucZi7BAuCECQcoKrMvDKk2szzAgmBMFgcQQOqIAQi6U42qQa7rFqhoaPEXC6VwUi6ZI8TGqQApCmpjrOq6jmkB6iAoKgAZBmQFAQGGuUgFGMZxgmmC7hmWYCrmdAFsQRZRCWZbEI2irVowBB1g2dotoYwDtkK%2BDdtUfYDkKQ4jmOHYTlOQoznOC4YKsQormuh4bluO4plVB65rIp7iBex7yEoah2roEL6P1z6WNYb5RB%2BnnCj%2BGQAcBYFQbBCFIShaEHJh2HpkKnHOERFHicEkzUf0ZF0QUmSeM0TH0RkUmw7YfHtAwnTDEjOS8fYBG4xMxRsXoxxifjpESaTUzSbJ0oKTJVocHy8V2mpGlaTpekGUZJlmRZ%2BBEMQNkyfZbrOa57mUEpHD%2BWuZrnAi8QaD5ZgQhCZgaGYXCGoa6wc6pDq2ClDlaO6Pp%2Btl4bBvlhURsV0YBGVSY7fuNVHnVhaUE1HalswrWVqQHW1vWjZDZgrYDStzZdvxY12pNyCjnH5CCJOdoLfOrWLuna3rnwW2VZ7IcnYd57SCd17nXeAyPsYL42AtT1fq9f6cIBn0wfBiHIah6GAzheFYwRLgQ9TehQ2Twkowj4nwyx0Pk4T/EdNxU9r9jJPoyJlN49kNMH3TMPsYz8nnvL7MJbwXOadpun6YZxlmKZ5mWaL4t2allvy4rIB1jrHOEA0BYDwHG0SqbJ0LoLaqlIBqHyrN1gqSgRwSWaUMpYJtjlCMIYCq2yKiVV2mB4zuz3NVcuPsGp%2B2akHNqVZso1i6hHXq0d%2BqDXjiNXs/Zk7DlTtNIUs1s6zlzhSfOy5TjrR4JtJg25S6UMPJeYQogjrV1kLXW8QpdBkUbrdKwr5W7wHbgRd6oEIK9x%2BgPf6GEzI4TMI6MeGQJ7uC3uRSiK855w2YhkRePjCieOkpjImAlD7I23sTcYe8KabyPjEwSgTYYXxlIpVmN9OacG5o/PmL9BYfxFtZDYEtf7wMQb5a0vBApagRIaMwkhta6nWBoLguotK6kgXfaB5s3TpWtllXB9tQyEKdsQ2MpDyoKL2t7fMvtiwBxagw0OTDOrdUjs2dhbZ07DUTrwwc/C07jkznNXgOclpLg7IXDaxc5HbQoVM5RlcJDqKvGdLROhch6NMHdQx75jEvVMV3D6Fjvr9z%2BkPOxwNHEhLBsRNxM96YYyXr4txSKAmzyCaDHGsTwnBPXlihJ6KMYn3EifaJLM5IpJZlOdJJt1IP15s/AWb8haf0KfKYpcCnKkBcm5foz0/KVP8Lqc4xp4i6hirrLWXAEQQnCh0%2B06CzawJ6dg/pds8pDIGZGF2YyyEVQ9oo2qMyaFzKFIHcsIcw4sJ6h2PqmzeoJ1Grsia%2BzBG8GEdOURZyC5SKLpuG5kyvYPNUVXZRmiLqAOuk%2BL5BiW6/M/P8t6gKe4gt%2BoPAGEKHG4uxi4yGFEyV5FRgIPxRaGAFsxSTElTiN4EoRfvbFBNaZkuScza%2BqDOl0p5k/fmr937CysmLIpP9OXS15R5f%2Bgr1iSFMpIDQCJmlSEkGaPU8qkpKpKVyspyD20KowX/BBIBGnnBii0sVGh1gInnesbWrMs1rjxC6W%2Bu6N3yyzU%2BtdI7SB9gas4yQQA%3D%3D%3D)): ![image](https://user-images.githubusercontent.com/10009354/209678087-977d494f-272c-4779-a3a5-994cf6da097a.png)

PS: Also note that some other makefiles in this repository sets this macro properly (to a value of 2, but still).