### PR TITLE
Remove register keyword as it has been deprecated since c++17

### DIFF
--- a/src/include/tcp.h
+++ b/src/include/tcp.h
@@ -38,6 +38,6 @@ int tcp_wcommit(struct tcp_chan *chan, int);
 int tcp_rskip(struct tcp_chan *chan,size_t);
 int tcp_chan_has_data(struct tcp_chan *chan);
 
-extern time_t pbs_tcp_timeout;
+extern "C" time_t pbs_tcp_timeout;
 
 #endif /* TCP_PBS_H */

--- a/src/lib/Libattr/attr_func.c
+++ b/src/lib/Libattr/attr_func.c
@@ -324,7 +324,7 @@ svrattrl *attrlist_alloc(
   int szval)   /* I */
 
   {
-  register size_t  tsize;
+  size_t  tsize;
   svrattrl        *pal;
 
   /* alloc memory block <SVRATTRL><NAME><RESC><VAL> */

--- a/src/resmom/cygwin/mom_mach.c
+++ b/src/resmom/cygwin/mom_mach.c
@@ -2773,7 +2773,7 @@ char *sessions(
   int            njids = 0;
   pid_t         *jids, *hold;
   static int     maxjid = 200;
-  register pid_t jobid;
+  pid_t jobid;
 
   if (attrib != NULL)
     {
@@ -3024,7 +3024,7 @@ char *nusers(
   int  nuids = 0;
   uid_t  *uids, *hold;
   static int maxuid = 200;
-  register uid_t uid;
+  uid_t uid;
 
   if (attrib != NULL)
     {

--- a/src/resmom/linux/mom_mach.c
+++ b/src/resmom/linux/mom_mach.c
@@ -4245,7 +4245,7 @@ const char *nusers(
   int                nuids = 0;
   uid_t             *uids, *hold;
   static int         maxuid = 200;
-  register uid_t     uid;
+  uid_t     uid;
 #ifdef NUMA_SUPPORT
   char               mom_check_name[PBS_MAXSERVERNAME], *s;
   job               *pjob;

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -1913,8 +1913,8 @@ void mom_server_all_update_stat(void)
 
 long power(
 
-  register int x,
-  register int n)
+  int x,
+  int n)
 
   {
   register long p;

--- a/src/resmom/mom_server_lib.h
+++ b/src/resmom/mom_server_lib.h
@@ -86,7 +86,7 @@ int send_update();
 
 void mom_server_all_update_stat(void);
 
-long power(register int x, register int n);
+long power(int x, int n);
 
 int calculate_retry_seconds(int count);
 

--- a/src/resmom/solaris7/mom_mach.c
+++ b/src/resmom/solaris7/mom_mach.c
@@ -1627,7 +1627,7 @@ sessions(struct rm_attribute *attrib)
   int   njids = 0;
   pid_t   *jids, *hold;
   static  int maxjid = 200;
-  register pid_t jobid;
+  pid_t jobid;
 
   if (attrib)
     {
@@ -1818,7 +1818,7 @@ nusers(struct rm_attribute *attrib)
   int   nuids = 0;
   uid_t   *uids, *hold;
   static  int maxuid = 200;
-  register uid_t uid;
+  uid_t uid;
 
   if (attrib)
     {

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -5310,10 +5310,10 @@ int node_avail(
   char           *pc;
 
   std::vector<prop>  plist;
-  register int    xavail;
-  register int    xalloc;
-  register int    xresvd;
-  register int    xdown;
+  int    xavail;
+  int    xalloc;
+  int    xresvd;
+  int    xdown;
   int             node_req = 1;
   int             gpu_req = 0;
   int             mic_req = 0;


### PR DESCRIPTION
Bug encontered on Gentoo with clang 16. Please refer
https://bugs.gentoo.org/898574